### PR TITLE
Set autocommit to true and change default distance metric to cosine

### DIFF
--- a/pyseekdb/client/client_base.py
+++ b/pyseekdb/client/client_base.py
@@ -1544,8 +1544,8 @@ class BaseClient(BaseConnection, AdminAPI):
         # Build WHERE clause from filters
         where_clause, params = self._build_where_clause(where, where_document)
         
-        # Get distance metric from kwargs, default to 'l2' if not provided
-        distance = kwargs.get('distance', 'l2')
+        # Get distance metric from kwargs, default to DEFAULT_DISTANCE_METRIC if not provided
+        distance = kwargs.get('distance', DEFAULT_DISTANCE_METRIC)
         
         # Map distance metric to SQL function name
         distance_function_map = {

--- a/pyseekdb/client/client_seekdb_server.py
+++ b/pyseekdb/client/client_seekdb_server.py
@@ -77,6 +77,7 @@ class RemoteServerClient(BaseClient):
                 database=self.database,
                 charset=self.charset,
                 cursorclass=DictCursor,
+                autocommit=True,
                 **self.kwargs
             )
             logger.info(f"✅ Connected to remote server: {self.host}:{self.port}/{self.database}")
@@ -107,7 +108,6 @@ class RemoteServerClient(BaseClient):
                 sql_upper.startswith('DESC')):
                 return cursor.fetchall()
             
-            conn.commit()
             return cursor
     
     def get_raw_connection(self) -> pymysql.Connection:

--- a/pyseekdb/tests/test_collection_dml.py
+++ b/pyseekdb/tests/test_collection_dml.py
@@ -71,7 +71,7 @@ class TestCollectionDML:
             {CollectionFieldNames.EMBEDDING} vector({dimension}),
             {CollectionFieldNames.METADATA} json,
             FULLTEXT INDEX idx_fts({CollectionFieldNames.DOCUMENT}),
-            VECTOR INDEX idx_vec ({CollectionFieldNames.EMBEDDING}) with(distance=l2, type=hnsw, lib=vsag)
+            VECTOR INDEX idx_vec ({CollectionFieldNames.EMBEDDING}) with(distance=cosine, type=hnsw, lib=vsag)
         ) ORGANIZATION = HEAP;"""
         client._server.execute(create_table_sql)
         
@@ -239,7 +239,7 @@ class TestCollectionDML:
             {CollectionFieldNames.EMBEDDING} vector({dimension}),
             {CollectionFieldNames.METADATA} json,
             FULLTEXT INDEX idx_fts({CollectionFieldNames.DOCUMENT}),
-            VECTOR INDEX idx_vec ({CollectionFieldNames.EMBEDDING}) with(distance=l2, type=hnsw, lib=vsag)
+            VECTOR INDEX idx_vec ({CollectionFieldNames.EMBEDDING}) with(distance=cosine, type=hnsw, lib=vsag)
         ) ORGANIZATION = HEAP;"""
         client._server.execute(create_table_sql)
         
@@ -442,7 +442,7 @@ class TestCollectionDML:
             {CollectionFieldNames.EMBEDDING} vector({dimension}),
             {CollectionFieldNames.METADATA} json,
             FULLTEXT INDEX idx_fts({CollectionFieldNames.DOCUMENT}),
-            VECTOR INDEX idx_vec ({CollectionFieldNames.EMBEDDING}) with(distance=l2, type=hnsw, lib=vsag)
+            VECTOR INDEX idx_vec ({CollectionFieldNames.EMBEDDING}) with(distance=cosine, type=hnsw, lib=vsag)
         ) ORGANIZATION = HEAP;"""
         client._server.execute(create_table_sql)
         


### PR DESCRIPTION
Set autocommit to true internally and change default distance metric to cosine

- Set autocommit=True internally for both embedded and server clients, remove autocommit parameter from user-facing API
- Remove manual commit/rollback calls from execute() method since autocommit handles transactions automatically
- Change default distance metric in query() from 'l2' to 'cosine' to match table creation defaults
- Fix fetchall() call for non-query statements (DELETE/UPDATE/INSERT) in embedded client
- Update test cases to use cosine distance consistently
