### PR TITLE
Support simplified equality syntax in where filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,11 +662,13 @@ results = collection.get(ids="123")
 # Get by multiple IDs
 results = collection.get(ids=["1", "2", "3"])
 
-# Get by metadata filter
+# Get by metadata filter (simplified equality - both forms are supported)
 results = collection.get(
-    where={"category": {"$eq": "AI"}},
+    where={"category": "AI"},
     limit=10
 )
+# Or use explicit $eq operator:
+# where={"category": {"$eq": "AI"}}
 
 # Get by comparison operator
 results = collection.get(
@@ -680,12 +682,12 @@ results = collection.get(
     limit=10
 )
 
-# Get by logical operators ($or)
+# Get by logical operators ($or) - simplified equality
 results = collection.get(
     where={
         "$or": [
-            {"category": {"$eq": "AI"}},
-            {"tag": {"$eq": "python"}}
+            {"category": "AI"},
+            {"tag": "python"}
         ]
     },
     limit=10
@@ -856,8 +858,12 @@ results = collection.hybrid_search(
 
 #### Metadata Filters (`where` parameter)
 
-- `$eq`: Equal to
+- `$eq`: Equal to (simplified form is also supported)
   ```python
+  # Simplified form (recommended for equality)
+  where={"category": "AI"}
+  
+  # Explicit $eq operator (also supported)
   where={"category": {"$eq": "AI"}}
   ```
 
@@ -898,22 +904,28 @@ results = collection.hybrid_search(
 
 - `$or`: Logical OR
   ```python
+  # Simplified equality form
   where={
       "$or": [
-          {"category": {"$eq": "AI"}},
-          {"tag": {"$eq": "python"}}
+          {"category": "AI"},
+          {"tag": "python"}
       ]
   }
+  # Or with explicit $eq:
+  # where={"$or": [{"category": {"$eq": "AI"}}, {"tag": {"$eq": "python"}}]}
   ```
 
 - `$and`: Logical AND
   ```python
+  # Simplified equality form
   where={
       "$and": [
-          {"category": {"$eq": "AI"}},
+          {"category": "AI"},
           {"score": {"$gte": 90}}
       ]
   }
+  # Or with explicit $eq:
+  # where={"$and": [{"category": {"$eq": "AI"}}, {"score": {"$gte": 90}}]}
   ```
 
 #### Document Filters (`where_document` parameter)

--- a/pyseekdb/examples/complete_example.py
+++ b/pyseekdb/examples/complete_example.py
@@ -206,10 +206,10 @@ results = collection.query(
 )
 print(f"Query results: {len(results['ids'][0])} items")
 
-# 6.2 Query with metadata filter
+# 6.2 Query with metadata filter (simplified equality)
 results = collection.query(
     query_embeddings=query_vector,
-    where={"category": {"$eq": "AI"}},
+    where={"category": "AI"},
     n_results=5
 )
 
@@ -227,24 +227,24 @@ results = collection.query(
     n_results=5
 )
 
-# 6.5 Query with logical operators ($or)
+# 6.5 Query with logical operators ($or) - simplified equality
 results = collection.query(
     query_embeddings=query_vector,
     where={
         "$or": [
-            {"category": {"$eq": "AI"}},
-            {"tag": {"$eq": "python"}}
+            {"category": "AI"},
+            {"tag": "python"}
         ]
     },
     n_results=5
 )
 
-# 6.6 Query with logical operators ($and)
+# 6.6 Query with logical operators ($and) - simplified equality
 results = collection.query(
     query_embeddings=query_vector,
     where={
         "$and": [
-            {"category": {"$eq": "AI"}},
+            {"category": "AI"},
             {"score": {"$gte": 90}}
         ]
     },
@@ -258,10 +258,10 @@ results = collection.query(
     n_results=5
 )
 
-# 6.8 Query with combined filters
+# 6.8 Query with combined filters (simplified equality)
 results = collection.query(
     query_embeddings=query_vector,
-    where={"category": {"$eq": "AI"}, "year": {"$gte": 2023}},
+    where={"category": "AI", "year": {"$gte": 2023}},
     where_document={"$contains": "learning"},
     n_results=5
 )
@@ -296,9 +296,9 @@ results = collection.get(ids=ids[:3])
 # results["ids"] contains ids[:3]
 # results["documents"] contains documents for all IDs
 
-# 7.3 Get by metadata filter
+# 7.3 Get by metadata filter (simplified equality)
 results = collection.get(
-    where={"category": {"$eq": "AI"}},
+    where={"category": "AI"},
     limit=5
 )
 
@@ -314,12 +314,12 @@ results = collection.get(
     limit=5
 )
 
-# 7.6 Get with logical operators
+# 7.6 Get with logical operators (simplified equality)
 results = collection.get(
     where={
         "$or": [
-            {"category": {"$eq": "AI"}},
-            {"category": {"$eq": "Programming"}}
+            {"category": "AI"},
+            {"category": "Programming"}
         ]
     },
     limit=5
@@ -354,7 +354,7 @@ all_results = collection.get(limit=100)
 hybrid_results = collection.hybrid_search(
     query={
         "where_document": {"$contains": "machine learning"},
-        "where": {"category": {"$eq": "AI"}},
+        "where": {"category": "AI"},  # Simplified equality
         "n_results": 10
     },
     knn={

--- a/pyseekdb/tests/test_collection_get.py
+++ b/pyseekdb/tests/test_collection_get.py
@@ -477,13 +477,13 @@ class TestCollectionGet:
             assert len(results) > 0
             print(f"   Found {len(results['ids'])} results with category='AI'")
             
-            # Test 4: Get by logical operators ($or)
+            # Test 4: Get by logical operators ($or) with simplified equality
             print(f"✅ Testing get with logical operators ($or)")
             results = collection.get(
                 where={
                     "$or": [
-                        {"category": {"$eq": "AI"}},
-                        {"tag": {"$eq": "python"}}
+                        {"category": "AI"},
+                        {"tag": "python"}
                     ]
                 },
                 limit=10

--- a/pyseekdb/tests/test_collection_hybrid_search.py
+++ b/pyseekdb/tests/test_collection_hybrid_search.py
@@ -743,7 +743,7 @@ class TestCollectionHybridSearch:
             # Wait a bit for indexes to be ready
             time.sleep(1)
             
-            # Test: Hybrid search with metadata filter
+            # Test: Hybrid search with metadata filter (simplified equality)
             print(f"\n✅ Testing hybrid_search with metadata filter (SeekdbServer)")
             results = collection.hybrid_search(
                 query={
@@ -752,7 +752,7 @@ class TestCollectionHybridSearch:
                     },
                     "where": {
                         "$and": [
-                            {"category": {"$eq": "AI"}},
+                            {"category": "AI"},
                             {"page": {"$gte": 1}},
                             {"page": {"$lte": 5}}
                         ]
@@ -763,7 +763,7 @@ class TestCollectionHybridSearch:
                     "query_embeddings": self._generate_query_vector(actual_dimension),
                     "where": {
                         "$and": [
-                            {"category": {"$eq": "AI"}},
+                            {"category": "AI"},
                             {"score": {"$gte": 90}}
                         ]
                     },

--- a/pyseekdb/tests/test_collection_query.py
+++ b/pyseekdb/tests/test_collection_query.py
@@ -164,11 +164,11 @@ class TestCollectionQuery:
             assert len(results["ids"][0]) > 0
             print(f"   Found {len(results['ids'][0])} results")
             
-            # Test 2: Query with metadata filter
+            # Test 2: Query with metadata filter (simplified equality)
             print(f"✅ Testing query with metadata filter")
             results = collection.query(
                 query_embeddings=query_vector,
-                where={"category": {"$eq": "AI"}},
+                where={"category": "AI"},
                 n_results=5
             )
             assert results is not None


### PR DESCRIPTION
Allow {"field": "value"} instead of {"field": {"": "value"}} for equality comparisons