### PR TITLE
enhance hybrid_search interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ hs = hs.knn({"query_texts": ["semantic search"], "where": {"topic": {"$eq": "nlp
 ```
 4) Ranking and final wiring
 ```python
-hs = hs.rank({"rrf": {}})   # or custom {"rrf": {"rank_window_size": 60, "rank_constant": 60}}
+hs = hs.rank()  # defaults to rrf; or hs.rank("rrf", rank_window_size=60, rank_constant=60)
 hs = hs.limit(5)            # final fused result count
 hs = hs.select(DOCUMENTS, METADATAS, EMBEDDINGS)  # include embeddings explicitly when needed
 ```
@@ -850,6 +850,7 @@ results = collection.hybrid_search(hs)
 ```
 6) Key behaviors & gotchas
 - Multiple `.query(...)` / `.knn(...)` calls produce multiple routes; `TEXT([...])` or multiple embeddings also auto-expand into multiple routes.
+- `.rank()` defaults to `rrf`; only `rrf` is supported, with optional `rank_window_size` and `rank_constant` keyword args. Dict form is still accepted but should not mix with kwargs.
 - `query_texts` requires the collection’s `embedding_function`; otherwise use `query_embeddings`.
 - Dimension mismatches (when `collection.dimension` is known) raise `ValueError`.
 - `ids`/`distances` always return; `documents`/`metadatas` return by default when `include=None`; add `embeddings` via `.select(...)` or `include` to fetch vectors.

--- a/examples/hybrid_search_example.py
+++ b/examples/hybrid_search_example.py
@@ -9,7 +9,13 @@ Key advantages of hybrid_search():
 """
 
 import pyseekdb
-from pyseekdb import DefaultEmbeddingFunction
+from pyseekdb import (
+    DefaultEmbeddingFunction,
+    HybridSearch,
+    DOCUMENT,
+    TEXT,
+    K,
+)
 
 # Setup
 client = pyseekdb.Client()
@@ -59,13 +65,22 @@ query_result1 = collection.query(
     n_results=5
 )
 
-# hybrid_search() approach
-hybrid_result1 = collection.hybrid_search(
-    query={"where_document": {"$contains": "machine learning"}, "n_results": 10},
-    knn={"query_texts": ["AI research"], "n_results": 10},
-    rank={"rrf": {}},
-    n_results=5
+# hybrid_search() approach (dict style)
+# hybrid_result1 = collection.hybrid_search(
+#     query={"where_document": {"$contains": "machine learning"}, "n_results": 10},
+#     knn={"query_texts": ["AI research"], "n_results": 10},
+#     rank={"rrf": {}},
+#     n_results=5
+# )
+# hybrid_search() approach (new HybridSearch builder)
+hybrid_search1 = (
+    HybridSearch()
+    .query(DOCUMENT.contains("machine learning"), n_results=10)
+    .knn(TEXT("AI research"), n_results=10)
+    .rank({"rrf": {}})
+    .limit(5)
 )
+hybrid_result1 = collection.hybrid_search(hybrid_search1)
 
 print("query() Results:")
 for i, doc_id in enumerate(query_result1['ids'][0]):
@@ -96,13 +111,22 @@ query_result2 = collection.query(
     n_results=5
 )
 
-# hybrid_search() - different filters for each search type
-hybrid_result2 = collection.hybrid_search(
-    query={"where_document": {"$contains": "neural"}, "where": {"year": {"$eq": 2024}}, "n_results": 10},
-    knn={"query_texts": ["deep learning"], "where": {"popularity": {"$gte": 90}}, "n_results": 10},
-    rank={"rrf": {}},
-    n_results=5
+# hybrid_search() - different filters for each search type (dict style)
+# hybrid_result2 = collection.hybrid_search(
+#     query={"where_document": {"$contains": "neural"}, "where": {"year": {"$eq": 2024}}, "n_results": 10},
+#     knn={"query_texts": ["deep learning"], "where": {"popularity": {"$gte": 90}}, "n_results": 10},
+#     rank={"rrf": {}},
+#     n_results=5
+# )
+# hybrid_search() - different filters for each search type (new builder)
+hybrid_search2 = (
+    HybridSearch()
+    .query(DOCUMENT.contains("neural"), K("year") == 2024, n_results=10)
+    .knn(TEXT("deep learning"), K("popularity") >= 90, n_results=10)
+    .rank({"rrf": {}})
+    .limit(5)
 )
+hybrid_result2 = collection.hybrid_search(hybrid_search2)
 
 print("query() Results (same filter for both):")
 for i, doc_id in enumerate(query_result2['ids'][0]):
@@ -133,13 +157,23 @@ query_result3 = collection.query(
     n_results=5
 )
 
-# hybrid_search() - combines full-text and vector
-hybrid_result3 = collection.hybrid_search(
-    query={"where_document": {"$contains": "machine learning"}, "n_results": 10},
-    knn={"query_texts": ["machine learning algorithms"], "n_results": 10},
-    rank={"rrf": {}},
-    n_results=5
+# hybrid_search() - combines full-text and vector (dict style)
+# hybrid_result3 = collection.hybrid_search(
+#     query={"where_document": {"$contains": "machine learning"}, "n_results": 10},
+#     knn={"query_texts": ["machine learning algorithms"], "n_results": 10},
+#     rank={"rrf": {}},
+#     n_results=5
+# )
+
+# hybrid_search() - combines full-text and vector (new builder)
+hybrid_search3 = (
+    HybridSearch()
+    .query(DOCUMENT.contains("machine learning"), n_results=10)
+    .knn(TEXT("machine learning algorithms"), n_results=10)
+    .rank({"rrf": {}})
+    .limit(5)
 )
+hybrid_result3 = collection.hybrid_search(hybrid_search3)
 
 print("query() Results (vector similarity only):")
 for i, doc_id in enumerate(query_result3['ids'][0]):
@@ -170,13 +204,23 @@ query_result4 = collection.query(
     n_results=5
 )
 
-# hybrid_search() - separate criteria for each search type
-hybrid_result4 = collection.hybrid_search(
-    query={"where_document": {"$contains": "learning"}, "where": {"category": {"$eq": "AI"}}, "n_results": 10},
-    knn={"query_texts": ["artificial intelligence"], "where": {"year": {"$gte": 2023}}, "n_results": 10},
-    rank={"rrf": {}},
-    n_results=5
+# hybrid_search() - separate criteria for each search type (dict style)
+# hybrid_result4 = collection.hybrid_search(
+#     query={"where_document": {"$contains": "learning"}, "where": {"category": {"$eq": "AI"}}, "n_results": 10},
+#     knn={"query_texts": ["artificial intelligence"], "where": {"year": {"$gte": 2023}}, "n_results": 10},
+#     rank={"rrf": {}},
+#     n_results=5
+# )
+
+# hybrid_search() - separate criteria for each search type (new builder)
+hybrid_search4 = (
+    HybridSearch()
+    .query(DOCUMENT.contains("learning"), K("category") == "AI", n_results=10)
+    .knn(TEXT("artificial intelligence"), K("year") >= 2023, n_results=10)
+    .rank({"rrf": {}})
+    .limit(5)
 )
+hybrid_result4 = collection.hybrid_search(hybrid_search4)
 
 print("query() Results:")
 for i, doc_id in enumerate(query_result4['ids'][0]):
@@ -208,13 +252,23 @@ query_result5 = collection.query(
     n_results=5
 )
 
-# hybrid_search() - RRF fusion of multiple rankings
-hybrid_result5 = collection.hybrid_search(
-    query={"where_document": {"$contains": "Python"}, "n_results": 10},
-    knn={"query_texts": ["Python machine learning"], "n_results": 10},
-    rank={"rrf": {}},
-    n_results=5
+# hybrid_search() - RRF fusion of multiple rankings (dict style)
+# hybrid_result5 = collection.hybrid_search(
+#     query={"where_document": {"$contains": "Python"}, "n_results": 10},
+#     knn={"query_texts": ["Python machine learning"], "n_results": 10},
+#     rank={"rrf": {}},
+#     n_results=5
+# )
+
+# hybrid_search() - RRF fusion of multiple rankings (new builder)
+hybrid_search5 = (
+    HybridSearch()
+    .query(DOCUMENT.contains("Python"), n_results=10)
+    .knn(TEXT("Python machine learning"), n_results=10)
+    .rank({"rrf": {}})
+    .limit(5)
 )
+hybrid_result5 = collection.hybrid_search(hybrid_search5)
 
 print("query() Results (single ranking):")
 for i, doc_id in enumerate(query_result5['ids'][0]):
@@ -246,13 +300,23 @@ query_result6 = collection.query(
     n_results=5
 )
 
-# hybrid_search() - different filters for keyword search vs semantic search
-hybrid_result6 = collection.hybrid_search(
-    query={"where_document": {"$contains": "neural"}, "where": {"popularity": {"$gte": 90}}, "n_results": 10},
-    knn={"query_texts": ["deep learning"], "where": {"year": {"$gte": 2023}}, "n_results": 10},
-    rank={"rrf": {}},
-    n_results=5
+# hybrid_search() - different filters for keyword search vs semantic search (dict style)
+# hybrid_result6 = collection.hybrid_search(
+#     query={"where_document": {"$contains": "neural"}, "where": {"popularity": {"$gte": 90}}, "n_results": 10},
+#     knn={"query_texts": ["deep learning"], "where": {"year": {"$gte": 2023}}, "n_results": 10},
+#     rank={"rrf": {}},
+#     n_results=5
+# )
+
+# hybrid_search() - different filters for keyword search vs semantic search (new builder)
+hybrid_search6 = (
+    HybridSearch()
+    .query(DOCUMENT.contains("neural"), K("popularity") >= 90, n_results=10)
+    .knn(TEXT("deep learning"), K("year") >= 2023, n_results=10)
+    .rank({"rrf": {}})
+    .limit(5)
 )
+hybrid_result6 = collection.hybrid_search(hybrid_search6)
 
 print("query() Results:")
 for i, doc_id in enumerate(query_result6['ids'][0]):
@@ -286,13 +350,23 @@ query_result7 = collection.query(
     n_results=5
 )
 
-# hybrid_search() - parallel searches then fusion
-hybrid_result7 = collection.hybrid_search(
-    query={"where_document": {"$contains": "Python"}, "n_results": 10},
-    knn={"query_texts": ["data science"], "n_results": 10},
-    rank={"rrf": {}},
-    n_results=5
+# hybrid_search() - parallel searches then fusion (dict style)
+# hybrid_result7 = collection.hybrid_search(
+#     query={"where_document": {"$contains": "Python"}, "n_results": 10},
+#     knn={"query_texts": ["data science"], "n_results": 10},
+#     rank={"rrf": {}},
+#     n_results=5
+# )
+
+# hybrid_search() - parallel searches then fusion (new builder)
+hybrid_search7 = (
+    HybridSearch()
+    .query(DOCUMENT.contains("Python"), n_results=10)
+    .knn(TEXT("data science"), n_results=10)
+    .rank({"rrf": {}})
+    .limit(5)
 )
+hybrid_result7 = collection.hybrid_search(hybrid_search7)
 
 print("query() Results:")
 for i, doc_id in enumerate(query_result7['ids'][0]):

--- a/src/pyseekdb/__init__.py
+++ b/src/pyseekdb/__init__.py
@@ -58,6 +58,18 @@ from .client import (
     Database,
 )
 from .client.collection import Collection
+from .client.hybrid_search import (
+    HybridSearch,
+    DOCUMENT,
+    TEXT,
+    EMBEDDINGS,
+    K,
+    IDS,
+    DOCUMENTS,
+    METADATAS,
+    EMBEDDINGS_FIELD,
+    SCORES,
+)
 
 try:
   __version__ = importlib.metadata.version("pyseekdb")
@@ -83,5 +95,15 @@ __all__ = [
     'AdminAPI',
     'AdminClient',
     'Database',
+    'HybridSearch',
+    'DOCUMENT',
+    'TEXT',
+    'EMBEDDINGS',
+    'K',
+    'IDS',
+    'DOCUMENTS',
+    'METADATAS',
+    'EMBEDDINGS_FIELD',
+    'SCORES',
 ]
 

--- a/src/pyseekdb/client/__init__.py
+++ b/src/pyseekdb/client/__init__.py
@@ -36,6 +36,18 @@ from .client_seekdb_embedded import SeekdbEmbeddedClient
 from .client_seekdb_server import RemoteServerClient
 from .database import Database
 from .admin_client import AdminAPI, _AdminClientProxy, _ClientProxy
+from .hybrid_search import (
+    HybridSearch,
+    DOCUMENT,
+    TEXT,
+    EMBEDDINGS,
+    K,
+    IDS,
+    DOCUMENTS,
+    METADATAS,
+    EMBEDDINGS_FIELD,
+    SCORES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +67,16 @@ __all__ = [
     'AdminAPI',
     'AdminClient',
     'Database',
+    'HybridSearch',
+    'DOCUMENT',
+    'TEXT',
+    'EMBEDDINGS',
+    'K',
+    'IDS',
+    'DOCUMENTS',
+    'METADATAS',
+    'EMBEDDINGS_FIELD',
+    'SCORES',
 ]
 
 def Client(

--- a/src/pyseekdb/client/collection.py
+++ b/src/pyseekdb/client/collection.py
@@ -442,11 +442,13 @@ class Collection:
                 - where_document: Document filter conditions (e.g., {"$contains": "text"})
                 - where: Metadata filter conditions (e.g., {"page": {"$gte": 5}})
                 - n_results: Number of results for full-text search (optional)
+                - boost: Weight for text query when combining hybrid results (optional)
             knn: Vector search configuration dict with:
                 - query_texts: Query text(s) to be embedded (optional if query_embeddings provided)
                 - query_embeddings: Query vector(s) (optional if query_texts provided)
                 - where: Metadata filter conditions (optional)
                 - n_results: Number of results for vector search (optional)
+                - boost: Weight for vector search when combining hybrid results (optional)
             rank: Ranking configuration dict (e.g., {"rrf": {"rank_window_size": 60, "rank_constant": 60}})
             n_results: Final number of results to return after ranking (default: 10)
             include: Fields to include in results (e.g., ["documents", "metadatas", "embeddings"])
@@ -466,12 +468,14 @@ class Collection:
                 query={
                     "where_document": {"$contains": "machine learning"},
                     "where": {"category": {"$eq": "science"}},
-                    "n_results": 10
+                    "n_results": 10,
+                    "boost": 0.5
                 },
                 knn={
                     "query_texts": ["AI research"],
                     "where": {"year": {"$gte": 2020}},
-                    "n_results": 10
+                    "n_results": 10,
+                    "boost": 0.3
                 },
                 rank={"rrf": {}},
                 n_results=5,

--- a/src/pyseekdb/client/hybrid_search.py
+++ b/src/pyseekdb/client/hybrid_search.py
@@ -1,0 +1,443 @@
+"""
+Hybrid search builder with a fluent interface.
+
+Provides a user-friendly way to construct hybrid_search parameters by chaining
+query/knn/rank/select/limit methods. Supports basic DSL helpers:
+- DOCUMENT.contains()/not_contains() for document filters
+- K("field") comparison operators for metadata filters
+- TEXT(...) for knn query_texts
+- EMBEDDINGS(...) for knn query_embeddings (callable and usable in select)
+
+The builder keeps payloads close to the existing hybrid_search() dict schema
+so the server-side SQL generation remains unchanged.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+__all__ = [
+    "HybridSearch",
+    "DOCUMENT",
+    "TEXT",
+    "EMBEDDINGS",
+    "K",
+    "IDS",
+    "DOCUMENTS",
+    "METADATAS",
+    "EMBEDDINGS_FIELD",
+    "SCORES",
+]
+
+
+class DocumentExpression:
+    """Wrapper for document filter expressions."""
+
+    def __init__(self, expression: Dict[str, Any]):
+        self._expression = expression
+
+    def to_dict(self) -> Dict[str, Any]:
+        return copy.deepcopy(self._expression)
+
+    def __and__(self, other: Any) -> "DocumentExpression":
+        other_expr = _as_document_expression(other)
+        return DocumentExpression({"$and": [self.to_dict(), other_expr.to_dict()]})
+
+    def __or__(self, other: Any) -> "DocumentExpression":
+        other_expr = _as_document_expression(other)
+        return DocumentExpression({"$or": [self.to_dict(), other_expr.to_dict()]})
+
+
+def _as_document_expression(value: Any) -> DocumentExpression:
+    if isinstance(value, DocumentExpression):
+        return value
+    if isinstance(value, dict):
+        return DocumentExpression(value)
+    if isinstance(value, str):
+        return DocumentExpression({"$contains": value})
+    raise TypeError(f"Unsupported document expression type: {type(value)}")
+
+
+class _DocumentBuilder:
+    """Entry point for building document filter expressions."""
+
+    def contains(self, text: Union[str, List[str]]) -> DocumentExpression:
+        if isinstance(text, list):
+            if len(text) == 1:
+                return DocumentExpression({"$contains": text[0]})
+            return DocumentExpression({"$and": [{"$contains": t} for t in text]})
+        return DocumentExpression({"$contains": text})
+
+    def not_contains(self, text: str) -> DocumentExpression:
+        return DocumentExpression({"$not_contains": text})
+
+
+DOCUMENT = _DocumentBuilder()
+
+
+class MetadataExpression:
+    """Wrapper for metadata filter expressions."""
+
+    def __init__(self, expression: Dict[str, Any]):
+        self._expression = expression
+
+    def to_dict(self) -> Dict[str, Any]:
+        return copy.deepcopy(self._expression)
+
+    def __and__(self, other: Any) -> "MetadataExpression":
+        other_expr = _as_metadata_expression(other)
+        return MetadataExpression({"$and": [self.to_dict(), other_expr.to_dict()]})
+
+    def __or__(self, other: Any) -> "MetadataExpression":
+        other_expr = _as_metadata_expression(other)
+        return MetadataExpression({"$or": [self.to_dict(), other_expr.to_dict()]})
+
+    def __invert__(self) -> "MetadataExpression":
+        return MetadataExpression({"$not": self.to_dict()})
+
+
+def _as_metadata_expression(value: Any) -> MetadataExpression:
+    if isinstance(value, MetadataExpression):
+        return value
+    if isinstance(value, dict):
+        return MetadataExpression(value)
+    raise TypeError(f"Unsupported metadata expression type: {type(value)}")
+
+
+class MetadataField:
+    """Metadata field helper supporting comparison operators."""
+
+    def __init__(self, key: str):
+        self._key = key
+
+    def _wrap(self, op: str, value: Any) -> MetadataExpression:
+        if op == "$eq":
+            return MetadataExpression({self._key: value})
+        return MetadataExpression({self._key: {op: value}})
+
+    def __eq__(self, other: Any) -> MetadataExpression:  # type: ignore[override]
+        return self._wrap("$eq", other)
+
+    def __ne__(self, other: Any) -> MetadataExpression:  # type: ignore[override]
+        return self._wrap("$ne", other)
+
+    def __lt__(self, other: Any) -> MetadataExpression:
+        return self._wrap("$lt", other)
+
+    def __le__(self, other: Any) -> MetadataExpression:
+        return self._wrap("$lte", other)
+
+    def __gt__(self, other: Any) -> MetadataExpression:
+        return self._wrap("$gt", other)
+
+    def __ge__(self, other: Any) -> MetadataExpression:
+        return self._wrap("$gte", other)
+
+    def is_in(self, values: Iterable[Any]) -> MetadataExpression:
+        """Membership check: field in given values."""
+        return self._wrap("$in", list(values))
+
+    def not_in(self, values: Iterable[Any]) -> MetadataExpression:
+        """Negated membership check: field not in given values."""
+        return self._wrap("$nin", list(values))
+
+
+def K(key: str) -> MetadataField:
+    """Metadata field alias."""
+    return MetadataField(key)
+
+
+class TextQuery:
+    """Container for knn query_texts."""
+
+    def __init__(self, texts: Union[str, List[str]]):
+        if isinstance(texts, str):
+            self.texts = [texts]
+        else:
+            self.texts = list(texts)
+
+
+class EmbeddingsQuery:
+    """Container for knn query_embeddings."""
+
+    def __init__(self, embeddings: Union[List[float], List[List[float]]]):
+        if embeddings is None:
+            raise ValueError("query_embeddings cannot be None")
+        vectors: List[List[float]] = []
+        if isinstance(embeddings, list) and embeddings and isinstance(embeddings[0], list):
+            vectors = [list(vec) for vec in embeddings]  # type: ignore[arg-type]
+        elif isinstance(embeddings, list):
+            vectors = [list(embeddings)]  # type: ignore[arg-type]
+        else:
+            raise TypeError(f"Unsupported embeddings type: {type(embeddings)}")
+        if not vectors:
+            raise ValueError("query_embeddings must not be empty")
+        self.vectors = vectors
+
+
+class _TextBuilder:
+    def __call__(self, texts: Union[str, List[str]]) -> TextQuery:
+        return TextQuery(texts)
+
+
+class _EmbeddingsBuilder:
+    field_name = "embeddings"
+
+    def __call__(self, embeddings: Union[List[float], List[List[float]]]) -> EmbeddingsQuery:
+        return EmbeddingsQuery(embeddings)
+
+
+TEXT = _TextBuilder()
+EMBEDDINGS = _EmbeddingsBuilder()
+
+# Select field constants
+IDS = "ids"
+DOCUMENTS = "documents"
+METADATAS = "metadatas"
+EMBEDDINGS_FIELD = "embeddings"
+SCORES = "scores"
+
+
+def _pop_n_results(kwargs: Dict[str, Any]) -> Optional[int]:
+    for key in ("n_results", "n_result", "nresult"):
+        if key in kwargs:
+            return kwargs.pop(key)
+    return None
+
+
+def _combine_filters(base: Optional[Dict[str, Any]], extras: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    filters: List[Dict[str, Any]] = []
+    if base:
+        filters.append(copy.deepcopy(base))
+    filters.extend(copy.deepcopy(item) for item in extras if item)
+    if not filters:
+        return None
+    if len(filters) == 1:
+        return filters[0]
+    return {"$and": filters}
+
+
+class HybridSearch:
+    """
+    Fluent builder for collection.hybrid_search().
+
+    Example:
+        search = (
+            HybridSearch()
+            .query(DOCUMENT.contains("machine learning"), K("category") == "AI", n_results=10, boost=0.5)
+            .knn(TEXT("AI research"), K("year") > 2020, n_results=10, boost=0.6)
+            .limit(5)
+            .select(IDS, DOCUMENTS, METADATAS, EMBEDDINGS, SCORES)
+        )
+    """
+
+    def __init__(
+        self,
+        query: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+        knn: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+        rank: Optional[Dict[str, Any]] = None,
+        n_results: Optional[int] = None,
+        nresult: Optional[int] = None,
+        include: Optional[List[str]] = None,
+    ):
+        self._queries: List[Dict[str, Any]] = []
+        self._knns: List[Dict[str, Any]] = []
+        self._rank = copy.deepcopy(rank) if rank else None
+        self._n_results = n_results if n_results is not None else nresult
+        self._include = copy.deepcopy(include) if include is not None else None
+
+        if query:
+            self._append_query_payload(query)
+        if knn:
+            self._append_knn_payload(knn)
+
+    def _append_query_payload(self, payload: Union[Dict[str, Any], List[Dict[str, Any]]]) -> None:
+        if isinstance(payload, list):
+            self._queries.extend(copy.deepcopy(payload))
+        else:
+            self._queries.append(copy.deepcopy(payload))
+
+    def _append_knn_payload(self, payload: Union[Dict[str, Any], List[Dict[str, Any]]]) -> None:
+        if isinstance(payload, list):
+            self._knns.extend(copy.deepcopy(payload))
+        else:
+            self._knns.append(copy.deepcopy(payload))
+
+    def query(self, *filters: Any, **kwargs) -> "HybridSearch":
+        n_results = _pop_n_results(kwargs)
+        boost = kwargs.pop("boost", None)
+        where = kwargs.pop("where", None)
+        where_document = kwargs.pop("where_document", None)
+
+        doc_filters: List[Dict[str, Any]] = []
+        meta_filters: List[Dict[str, Any]] = []
+        for item in filters:
+            if isinstance(item, DocumentExpression):
+                doc_filters.append(item.to_dict())
+            elif isinstance(item, MetadataExpression):
+                meta_filters.append(item.to_dict())
+            elif isinstance(item, dict):
+                # Heuristic: document filter keys contain $contains/$not_contains/$and/$or
+                if any(key in item for key in ("$contains", "$not_contains", "$and", "$or")):
+                    doc_filters.append(copy.deepcopy(item))
+                else:
+                    meta_filters.append(copy.deepcopy(item))
+            elif isinstance(item, str):
+                doc_filters.append(DocumentExpression({"$contains": item}).to_dict())
+
+        final_where_document = _combine_filters(where_document, doc_filters)
+        final_where = _combine_filters(where, meta_filters)
+
+        query_payload: Dict[str, Any] = {}
+        if final_where_document is not None:
+            query_payload["where_document"] = final_where_document
+        if final_where is not None:
+            query_payload["where"] = final_where
+        if n_results is not None:
+            query_payload["n_results"] = n_results
+        if boost is not None:
+            query_payload["boost"] = boost
+
+        if query_payload:
+            self._queries.append(query_payload)
+        return self
+
+    def knn(self, *filters: Any, **kwargs) -> "HybridSearch":
+        n_results = _pop_n_results(kwargs)
+        boost = kwargs.pop("boost", None)
+        where = kwargs.pop("where", None)
+        query_texts = kwargs.pop("query_texts", None)
+        query_embeddings = kwargs.pop("query_embeddings", None)
+
+        text_arg: Optional[TextQuery] = None
+        emb_arg: Optional[EmbeddingsQuery] = None
+        meta_filters: List[Dict[str, Any]] = []
+
+        if len(filters) == 1 and isinstance(filters[0], dict) and not any(
+            [query_texts, query_embeddings, where]
+        ):
+            # Direct knn payload
+            knn_payload = copy.deepcopy(filters[0])
+            if n_results is not None:
+                knn_payload["n_results"] = n_results
+            if boost is not None:
+                knn_payload["boost"] = boost
+            self._knns.append(knn_payload)
+            return self
+
+        for item in filters:
+            if isinstance(item, TextQuery):
+                text_arg = item
+            elif isinstance(item, EmbeddingsQuery):
+                emb_arg = item
+            elif isinstance(item, MetadataExpression):
+                meta_filters.append(item.to_dict())
+            elif isinstance(item, dict):
+                meta_filters.append(copy.deepcopy(item))
+            elif isinstance(item, str) and text_arg is None and query_texts is None:
+                text_arg = TextQuery(item)
+
+        if emb_arg is not None:
+            query_embeddings = emb_arg.vectors
+        if text_arg is not None and query_embeddings is None:
+            query_texts = text_arg.texts
+
+        final_where = _combine_filters(where, meta_filters)
+
+        knn_payload: Dict[str, Any] = {}
+        if query_texts is not None:
+            knn_payload["query_texts"] = query_texts
+        if query_embeddings is not None:
+            knn_payload["query_embeddings"] = query_embeddings
+        if final_where is not None:
+            knn_payload["where"] = final_where
+        if n_results is not None:
+            knn_payload["n_results"] = n_results
+        if boost is not None:
+            knn_payload["boost"] = boost
+
+        if not knn_payload.get("query_texts") and not knn_payload.get("query_embeddings"):
+            raise ValueError("knn requires either query_texts or query_embeddings")
+
+        self._knns.append(knn_payload)
+        return self
+
+    def rank(self, rank: Dict[str, Any]) -> "HybridSearch":
+        if rank is not None:
+            self._rank = copy.deepcopy(rank)
+        return self
+
+    def limit(self, n_results: int) -> "HybridSearch":
+        self._n_results = n_results
+        return self
+
+    def select(self, *fields: Any) -> "HybridSearch":
+        include: List[str] = []
+        for field in fields:
+            if field is None:
+                continue
+            if field is EMBEDDINGS or isinstance(field, _EmbeddingsBuilder):
+                if EMBEDDINGS_FIELD not in include:
+                    include.append(EMBEDDINGS_FIELD)
+                continue
+            if isinstance(field, str):
+                name = field.lower()
+                if name in ("documents", "metadatas", "embeddings"):
+                    if name not in include:
+                        include.append(name)
+        self._include = include
+        return self
+
+    def to_params(self, dimension: Optional[int] = None) -> Dict[str, Any]:
+        """Return a dict containing query/knn/rank/include/n_results for hybrid_search."""
+        query_param: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None
+        if self._queries:
+            query_param = (
+                self._queries[0] if len(self._queries) == 1 else copy.deepcopy(self._queries)
+            )
+
+        knn_param: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None
+        if self._knns:
+            knn_param = (
+                self._knns[0] if len(self._knns) == 1 else copy.deepcopy(self._knns)
+            )
+
+        self._validate_knn_embeddings(knn_param, dimension)
+
+        return {
+            "query": query_param,
+            "knn": knn_param,
+            "rank": copy.deepcopy(self._rank) if self._rank else None,
+            "n_results": self._n_results,
+            "include": copy.deepcopy(self._include) if self._include is not None else None,
+        }
+
+    @staticmethod
+    def _validate_knn_embeddings(
+        knn_param: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]],
+        dimension: Optional[int],
+    ) -> None:
+        if dimension is None or not knn_param:
+            return
+
+        def _validate_vector(vec: List[Any]) -> None:
+            if len(vec) != dimension:
+                raise ValueError(
+                    f"Embedding dimension mismatch: expected {dimension}, got {len(vec)}"
+                )
+
+        def _extract_vectors(payload: Dict[str, Any]) -> List[List[Any]]:
+            embeddings = payload.get("query_embeddings")
+            if embeddings is None:
+                return []
+            if isinstance(embeddings, list) and embeddings and isinstance(embeddings[0], list):
+                return embeddings  # type: ignore[return-value]
+            if isinstance(embeddings, list):
+                return [embeddings]  # type: ignore[list-item]
+            return []
+
+        payloads = knn_param if isinstance(knn_param, list) else [knn_param]
+        for payload in payloads:
+            for vec in _extract_vectors(payload):
+                _validate_vector(vec)
+

--- a/tests/test_admin_database_management.py
+++ b/tests/test_admin_database_management.py
@@ -17,7 +17,7 @@ import pyseekdb
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb_store"))
+SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb.db"))
 
 # Server mode (seekdb Server)
 SERVER_HOST = os.environ.get('SERVER_HOST', '127.0.0.1')

--- a/tests/test_client_creation.py
+++ b/tests/test_client_creation.py
@@ -17,7 +17,7 @@ import pyseekdb
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb_store"))
+SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb.db"))
 SEEKDB_DATABASE = os.environ.get('SEEKDB_DATABASE', 'test')
 
 # Server mode

--- a/tests/test_collection_dml.py
+++ b/tests/test_collection_dml.py
@@ -19,7 +19,7 @@ from pyseekdb.client.meta_info import CollectionNames, CollectionFieldNames
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb_store"))
+SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb.db"))
 SEEKDB_DATABASE = os.environ.get('SEEKDB_DATABASE', 'test')
 
 # Server mode

--- a/tests/test_collection_embedding_function.py
+++ b/tests/test_collection_embedding_function.py
@@ -68,7 +68,7 @@ class Simple128DEmbeddingFunction:
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb_store"))
+SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb.db"))
 SEEKDB_DATABASE = os.environ.get('SEEKDB_DATABASE', 'test')
 
 # Server mode

--- a/tests/test_collection_get.py
+++ b/tests/test_collection_get.py
@@ -46,7 +46,7 @@ class Simple3DEmbeddingFunction:
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb_store"))
+SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb.db"))
 SEEKDB_DATABASE = os.environ.get('SEEKDB_DATABASE', 'test')
 
 # Server mode

--- a/tests/test_collection_hybrid_search.py
+++ b/tests/test_collection_hybrid_search.py
@@ -351,11 +351,13 @@ class TestCollectionHybridSearch:
                     "where_document": {
                         "$contains": "machine learning"
                     },
-                    "n_results": 10
+                    "n_results": 10,
+                    "boost": 0.4
                 },
                 knn={
                     "query_embeddings": self._generate_query_vector(actual_dimension),
-                    "n_results": 10
+                    "n_results": 10,
+                    "boost": 1.6
                 },
                 rank={
                     "rrf": {
@@ -630,11 +632,13 @@ class TestCollectionHybridSearch:
                     "where_document": {
                         "$contains": "machine learning"
                     },
-                    "n_results": 10
+                    "n_results": 10,
+                    "boost": 0.4
                 },
                 knn={
                     "query_embeddings": self._generate_query_vector(actual_dimension),
-                    "n_results": 10
+                    "n_results": 10,
+                    "boost": 1.6
                 },
                 rank={
                     "rrf": {
@@ -1005,11 +1009,13 @@ class TestCollectionHybridSearch:
                     "where_document": {
                         "$contains": "machine learning"
                     },
-                    "n_results": 10
+                    "n_results": 10,
+                    "boost": 0.4
                 },
                 knn={
                     "query_embeddings": self._generate_query_vector(actual_dimension),
-                    "n_results": 10
+                    "n_results": 10,
+                    "boost": 1.6
                 },
                 rank={
                     "rrf": {

--- a/tests/test_collection_hybrid_search.py
+++ b/tests/test_collection_hybrid_search.py
@@ -245,6 +245,26 @@ class TestCollectionHybridSearch:
             for doc in results["documents"][0]:
                 if doc:
                     assert "machine" in doc.lower() or "learning" in doc.lower()
+
+            # Test 1b: Full-text search with $not_contains
+            print(f"   Testing hybrid_search with $not_contains filter")
+            forbidden_phrase = "machine learning"
+            results_not = collection.hybrid_search(
+                query={
+                    "where_document": {
+                        "$not_contains": forbidden_phrase
+                    }
+                },
+                n_results=5,
+                include=["documents", "metadatas"]
+            )
+
+            assert results_not is not None
+            assert "documents" in results_not
+            docs_not = results_not["documents"][0] if results_not.get("documents") else []
+            for doc in docs_not:
+                if doc:
+                    assert forbidden_phrase not in doc.lower()
             
         finally:
             # Cleanup
@@ -590,6 +610,26 @@ class TestCollectionHybridSearch:
             for doc in results["documents"][0]:
                 if doc:
                     assert "machine" in doc.lower() or "learning" in doc.lower()
+
+            # Test 1b: Full-text search with $not_contains
+            print(f"   Testing hybrid_search with $not_contains filter (SeekdbServer)")
+            forbidden_phrase = "machine learning"
+            results_not = collection.hybrid_search(
+                query={
+                    "where_document": {
+                        "$not_contains": forbidden_phrase
+                    }
+                },
+                n_results=5,
+                include=["documents", "metadatas"]
+            )
+
+            assert results_not is not None
+            assert "documents" in results_not
+            docs_not = results_not["documents"][0] if results_not.get("documents") else []
+            for doc in docs_not:
+                if doc:
+                    assert forbidden_phrase not in doc.lower()
             
         finally:
             # Cleanup
@@ -918,6 +958,26 @@ class TestCollectionHybridSearch:
             for doc in results["documents"][0]:
                 if doc:
                     assert "machine" in doc.lower() or "learning" in doc.lower()
+
+            # Test 1b: Full-text search with $not_contains
+            print(f"   Testing hybrid_search with $not_contains filter (SeekdbEmbedded)")
+            forbidden_phrase = "machine learning"
+            results_not = collection.hybrid_search(
+                query={
+                    "where_document": {
+                        "$not_contains": forbidden_phrase
+                    }
+                },
+                n_results=5,
+                include=["documents", "metadatas"]
+            )
+
+            assert results_not is not None
+            assert "documents" in results_not
+            docs_not = results_not["documents"][0] if results_not.get("documents") else []
+            for doc in docs_not:
+                if doc:
+                    assert forbidden_phrase not in doc.lower()
             
         finally:
             # Cleanup

--- a/tests/test_collection_hybrid_search_builder_integration.py
+++ b/tests/test_collection_hybrid_search_builder_integration.py
@@ -307,7 +307,7 @@ class TestCollectionHybridSearchWithBuilder:
                 lambda hs: hs
                 .query(DOCUMENT.contains("machine learning"), n_results=10, boost=0.4)
                 .knn(EMBEDDINGS(self._generate_query_vector(actual_dimension)), n_results=10, boost=1.6)
-                .rank({"rrf": {"rank_window_size": 60, "rank_constant": 60}})
+                .rank("rrf", rank_window_size=60, rank_constant=60)
                 .limit(5)
                 .select(DOCUMENTS, METADATAS, EMBEDDINGS_FIELD)
             )
@@ -411,7 +411,7 @@ class TestCollectionHybridSearchWithBuilder:
                     K("tag").is_in(["ml", "python"]),
                     n_results=10
                 )
-                .rank({"rrf": {}})
+                .rank()
                 .limit(5)
                 .select(DOCUMENTS, METADATAS)
             )
@@ -577,7 +577,7 @@ class TestCollectionHybridSearchWithBuilder:
                 lambda hs: hs
                 .query(DOCUMENT.contains("machine learning"), n_results=10, boost=0.4)
                 .knn(EMBEDDINGS(self._generate_query_vector(actual_dimension)), n_results=10, boost=1.6)
-                .rank({"rrf": {"rank_window_size": 60, "rank_constant": 60}})
+                .rank("rrf", rank_window_size=60, rank_constant=60)
                 .limit(5)
                 .select(DOCUMENTS, METADATAS, EMBEDDINGS_FIELD)
             )
@@ -721,7 +721,7 @@ class TestCollectionHybridSearchWithBuilder:
                     K("tag").is_in(["ml", "python"]),
                     n_results=10
                 )
-                .rank({"rrf": {}})
+                .rank()
                 .limit(5)
                 .select(DOCUMENTS, METADATAS)
             )
@@ -970,7 +970,7 @@ class TestCollectionHybridSearchWithBuilder:
                 lambda hs: hs
                 .query(DOCUMENT.contains("machine learning"), n_results=10, boost=0.4)
                 .knn(EMBEDDINGS(self._generate_query_vector(actual_dimension)), n_results=10, boost=1.6)
-                .rank({"rrf": {"rank_window_size": 60, "rank_constant": 60}})
+                .rank("rrf", rank_window_size=60, rank_constant=60)
                 .limit(5)
                 .select(DOCUMENTS, METADATAS, EMBEDDINGS_FIELD)
             )
@@ -1063,7 +1063,7 @@ class TestCollectionHybridSearchWithBuilder:
                     K("tag").is_in(["ml", "python"]),
                     n_results=10
                 )
-                .rank({"rrf": {}})
+                .rank()
                 .limit(5)
                 .select(DOCUMENTS, METADATAS)
             )

--- a/tests/test_collection_query.py
+++ b/tests/test_collection_query.py
@@ -19,7 +19,7 @@ import pyseekdb
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb_store"))
+SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb.db"))
 SEEKDB_DATABASE = os.environ.get('SEEKDB_DATABASE', 'test')
 
 # Server mode

--- a/tests/test_default_embedding_function.py
+++ b/tests/test_default_embedding_function.py
@@ -23,7 +23,7 @@ from pyseekdb import DefaultEmbeddingFunction
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb_store"))
+SEEKDB_PATH = os.environ.get('SEEKDB_PATH', os.path.join(project_root, "seekdb.db"))
 SEEKDB_DATABASE = os.environ.get('SEEKDB_DATABASE', 'test')
 
 # Server mode

--- a/tests/test_offical_case.py
+++ b/tests/test_offical_case.py
@@ -23,7 +23,7 @@ import pyseekdb  # noqa: E402
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get("SEEKDB_PATH", os.path.join(project_root, "seekdb_store"))
+SEEKDB_PATH = os.environ.get("SEEKDB_PATH", os.path.join(project_root, "seekdb.db"))
 SEEKDB_DATABASE = os.environ.get("SEEKDB_DATABASE", "test")
 
 # Server mode


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
- Added HybridSearch fluent builder with DSL helpers (DOCUMENT.contains/not_contains, K().is_in/not_in, TEXT/EMBEDDINGS) plus chaining of .query()/.knn()/.rank()/.limit()/.select(), exposed in __init__, documented in README, example, and integration tests.

- hybrid_search() now accepts per-route boost, with collection forwarding updated.

- Document filters support $not_contains.

- Metadata filters support $in / $nin (mirrored by K().is_in/not_in), with tests expanded.

