### PR TITLE
Add basic functionality tests for detect_db_type_and_version method

### DIFF
--- a/src/pyseekdb/__init__.py
+++ b/src/pyseekdb/__init__.py
@@ -56,6 +56,7 @@ from .client import (
     AdminAPI,
     AdminClient,
     Database,
+    Version,
 )
 from .client.collection import Collection
 
@@ -83,5 +84,6 @@ __all__ = [
     'AdminAPI',
     'AdminClient',
     'Database',
+    'Version',
 ]
 

--- a/src/pyseekdb/client/__init__.py
+++ b/src/pyseekdb/client/__init__.py
@@ -35,6 +35,7 @@ from .embedding_function import (
 from .client_seekdb_embedded import SeekdbEmbeddedClient
 from .client_seekdb_server import RemoteServerClient
 from .database import Database
+from .version import Version
 from .admin_client import AdminAPI, _AdminClientProxy, _ClientProxy
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,7 @@ __all__ = [
     'AdminAPI',
     'AdminClient',
     'Database',
+    'Version',
 ]
 
 def Client(

--- a/src/pyseekdb/client/client_seekdb_server.py
+++ b/src/pyseekdb/client/client_seekdb_server.py
@@ -3,7 +3,7 @@ Remote server mode client - based on pymysql
 Supports both seekdb Server and OceanBase Server
 """
 import logging
-from typing import Any, List, Optional, Sequence, Dict, Union
+from typing import Any, Optional, Sequence, Tuple
 
 import pymysql
 from pymysql.cursors import DictCursor

--- a/src/pyseekdb/client/version.py
+++ b/src/pyseekdb/client/version.py
@@ -1,0 +1,122 @@
+"""
+Version class for representing and comparing database versions
+"""
+from typing import List, Optional, Tuple
+
+
+class Version:
+    """
+    Represents a version number with support for comparison operations.
+    
+    Supports versions in format: x.x.x or x.x.x.x (3 or 4 numeric parts)
+    
+    Examples:
+        >>> v1 = Version("1.0.1.0")
+        >>> v2 = Version("1.0.0.1")
+        >>> v1 > v2
+        True
+        
+        >>> v1 = Version("1.2.3")
+        >>> v2 = Version("1.2.4")
+        >>> v1 < v2
+        True
+    """
+    
+    def __init__(self, version_str: str):
+        """
+        Initialize Version from string.
+        
+        Args:
+            version_str: Version string in format x.x.x or x.x.x.x
+            
+        Raises:
+            ValueError: If version string format is invalid
+        """
+        if not version_str:
+            raise ValueError("Version string cannot be empty")
+        
+        parts = version_str.split('.')
+        if len(parts) not in (3, 4):
+            raise ValueError(
+                f"Version format should be x.x.x or x.x.x.x (3 or 4 numeric parts), got: {version_str}"
+            )
+        
+        try:
+            self._parts = [int(part) for part in parts]
+        except ValueError as e:
+            raise ValueError(
+                f"Version parts must be numeric, got: {version_str}"
+            ) from e
+        
+        # Normalize to 4 parts for comparison (pad with 0 if needed)
+        if len(self._parts) == 3:
+            self._parts.append(0)
+    
+    @property
+    def parts(self) -> Tuple[int, int, int, int]:
+        """Get version parts as tuple"""
+        return tuple(self._parts)
+    
+    @property
+    def major(self) -> int:
+        """Get major version number"""
+        return self._parts[0]
+    
+    @property
+    def minor(self) -> int:
+        """Get minor version number"""
+        return self._parts[1]
+    
+    @property
+    def patch(self) -> int:
+        """Get patch version number"""
+        return self._parts[2]
+    
+    @property
+    def build(self) -> int:
+        """Get build version number (0 if not specified)"""
+        return self._parts[3]
+    
+    def __str__(self) -> str:
+        """Convert to string representation"""
+        # Always return full version (preserve all parts including trailing .0)
+        return '.'.join(str(p) for p in self._parts)
+    
+    def __repr__(self) -> str:
+        """Representation for debugging"""
+        return f"Version('{self}')"
+    
+    def __eq__(self, other) -> bool:
+        """Check equality"""
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._parts == other._parts
+    
+    def __lt__(self, other) -> bool:
+        """Check if less than"""
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._parts < other._parts
+    
+    def __le__(self, other) -> bool:
+        """Check if less than or equal"""
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._parts <= other._parts
+    
+    def __gt__(self, other) -> bool:
+        """Check if greater than"""
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._parts > other._parts
+    
+    def __ge__(self, other) -> bool:
+        """Check if greater than or equal"""
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._parts >= other._parts
+    
+    def __hash__(self) -> int:
+        """Hash for use in sets and dicts"""
+        return hash(tuple(self._parts))
+

--- a/tests/test_detect_db_type_and_version.py
+++ b/tests/test_detect_db_type_and_version.py
@@ -1,0 +1,231 @@
+"""
+Tests for detect_db_type_and_version method
+Tests database type and version detection functionality for all client modes (embedded, server, oceanbase)
+Supports configuring connection parameters via environment variables
+"""
+import pytest
+import sys
+import os
+from pathlib import Path
+
+# Add project path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import pyseekdb
+from pyseekdb.client.version import Version
+
+
+# ==================== Environment Variable Configuration ====================
+# Server mode (seekdb Server)
+SERVER_HOST = os.environ.get('SERVER_HOST', '127.0.0.1')
+SERVER_PORT = int(os.environ.get('SERVER_PORT', '2881'))
+SERVER_DATABASE = os.environ.get('SERVER_DATABASE', 'test')
+SERVER_USER = os.environ.get('SERVER_USER', 'root')
+SERVER_PASSWORD = os.environ.get('SERVER_PASSWORD', '')
+
+# OceanBase mode
+OB_HOST = os.environ.get('OB_HOST', 'localhost')
+OB_PORT = int(os.environ.get('OB_PORT', '11202'))
+OB_TENANT = os.environ.get('OB_TENANT', 'mysql')
+OB_DATABASE = os.environ.get('OB_DATABASE', 'test')
+OB_USER = os.environ.get('OB_USER', 'root')
+OB_PASSWORD = os.environ.get('OB_PASSWORD', '')
+
+
+class TestDetectDbTypeAndVersion:
+    """Tests for detect_db_type_and_version method"""
+    
+    def test_server_detect_seekdb(self):
+        """Basic test: detect seekdb Server type and version"""
+        # Create server client (returns _ClientProxy)
+        client = pyseekdb.Client(
+            host=SERVER_HOST,
+            port=SERVER_PORT,
+            tenant="sys",  # Default tenant for seekdb Server
+            database=SERVER_DATABASE,
+            user=SERVER_USER,
+            password=SERVER_PASSWORD
+        )
+        
+        # Verify client type
+        assert client is not None
+        assert hasattr(client, '_server')
+        assert isinstance(client._server, pyseekdb.RemoteServerClient)
+        
+        # Test connection and detection
+        try:
+            # Ensure connection is established
+            result = client._server.execute("SELECT 1 as test")
+            assert result is not None
+            
+            # Test detect_db_type_and_version
+            db_type, version = client._server.detect_db_type_and_version()
+            
+            # Verify results
+            assert db_type == "seekdb"
+            assert version is not None
+            assert isinstance(version, Version)
+            # Test version comparison
+            assert version > Version("0.0.0.0"), f"Version should be greater than 0.0.0.0, got: {version}"
+            
+            print(f"\n✅ Successfully detected seekdb Server")
+            print(f"   Database type: {db_type}")
+            print(f"   Version: {version}")
+            
+        except Exception as e:
+            pytest.fail(f"seekdb Server detection failed ({SERVER_HOST}:{SERVER_PORT}): {e}\n"
+                       f"Hint: Please ensure seekdb Server is running on port {SERVER_PORT}")
+    
+    def test_oceanbase_detect_oceanbase(self):
+        """Basic test: detect OceanBase Server type and version"""
+        # Create OceanBase client (returns _ClientProxy)
+        client = pyseekdb.Client(
+            host=OB_HOST,
+            port=OB_PORT,
+            tenant=OB_TENANT,
+            database=OB_DATABASE,
+            user=OB_USER,
+            password=OB_PASSWORD
+        )
+        
+        # Verify client type
+        assert client is not None
+        assert hasattr(client, '_server')
+        assert isinstance(client._server, pyseekdb.RemoteServerClient)
+        
+        # Test connection and detection
+        try:
+            # Ensure connection is established
+            result = client._server.execute("SELECT 1 as test")
+            assert result is not None
+            
+            # Test detect_db_type_and_version
+            db_type, version = client._server.detect_db_type_and_version()
+            
+            # Verify results
+            assert db_type == "oceanbase"
+            assert version is not None
+            assert isinstance(version, Version)
+            # Test version comparison
+            assert version > Version("0.0.0.0"), f"Version should be greater than 0.0.0.0, got: {version}"
+            
+            print(f"\n✅ Successfully detected OceanBase Server")
+            print(f"   Database type: {db_type}")
+            print(f"   Version: {version}")
+            
+        except Exception as e:
+            pytest.fail(f"OceanBase Server detection failed ({OB_HOST}:{OB_PORT}): {e}\n"
+                       f"Hint: Please ensure OceanBase is running and tenant '{OB_TENANT}' is created")
+    
+    def test_server_connection_establishment(self):
+        """Basic test: verify detect_db_type_and_version establishes connection automatically"""
+        # Create server client (returns _ClientProxy)
+        client = pyseekdb.Client(
+            host=SERVER_HOST,
+            port=SERVER_PORT,
+            tenant="sys",
+            database=SERVER_DATABASE,
+            user=SERVER_USER,
+            password=SERVER_PASSWORD
+        )
+        
+        # Verify client is not connected initially (lazy loading)
+        assert not client._server.is_connected()
+        
+        try:
+            # Call detect_db_type_and_version (should establish connection)
+            db_type, version = client._server.detect_db_type_and_version()
+            
+            # Verify connection was established
+            assert client._server.is_connected()
+            
+            # Verify results
+            assert db_type in ["seekdb", "oceanbase"]
+            assert version is not None
+            
+            print(f"\n✅ detect_db_type_and_version successfully established connection")
+            print(f"   Database type: {db_type}")
+            print(f"   Version: {version}")
+            
+        except Exception as e:
+            pytest.fail(f"Connection establishment test failed ({SERVER_HOST}:{SERVER_PORT}): {e}")
+    
+    def test_server_return_format(self):
+        """Basic test: verify detect_db_type_and_version returns correct tuple format"""
+        # Create server client (returns _ClientProxy)
+        client = pyseekdb.Client(
+            host=SERVER_HOST,
+            port=SERVER_PORT,
+            tenant="sys",
+            database=SERVER_DATABASE,
+            user=SERVER_USER,
+            password=SERVER_PASSWORD
+        )
+        
+        try:
+            # Test detect_db_type_and_version
+            result = client._server.detect_db_type_and_version()
+            
+            # Verify return type is tuple
+            assert isinstance(result, tuple)
+            assert len(result) == 2
+            
+            db_type, version = result
+            
+            # Verify tuple elements
+            assert isinstance(db_type, str)
+            assert isinstance(version, Version)
+            assert db_type in ["seekdb", "oceanbase"]
+            assert version > Version("0.0.0.0")
+            
+            print(f"\n✅ detect_db_type_and_version returns correct tuple format")
+            print(f"   Result: {result}")
+            print(f"   Type: {type(result)}")
+            print(f"   Length: {len(result)}")
+            
+        except Exception as e:
+            pytest.fail(f"Return format test failed ({SERVER_HOST}:{SERVER_PORT}): {e}")
+    
+    def test_server_version_comparison(self):
+        """Test Version class comparison functionality (pure unit test, no database connection required)"""
+        # Test version comparison as mentioned in code review
+        version1 = Version("1.0.1.0")
+        version2 = Version("1.0.0.1")
+        
+        # version1 should be greater than version2
+        assert version1 > version2, f"Expected {version1} > {version2}"
+        assert version1 >= version2, f"Expected {version1} >= {version2}"
+        assert version2 < version1, f"Expected {version2} < {version1}"
+        assert version2 <= version1, f"Expected {version2} <= {version1}"
+        assert version1 != version2, f"Expected {version1} != {version2}"
+        
+        # Test equality
+        version3 = Version("1.0.1.0")
+        assert version1 == version3, f"Expected {version1} == {version3}"
+        
+        # Test 3-part version (should be normalized to 4 parts)
+        version4 = Version("1.2.3")
+        version5 = Version("1.2.3.0")
+        assert version4 == version5, f"Expected {version4} == {version5}"
+        
+        # Test string representation (preserve all parts including trailing .0)
+        assert str(version1) == "1.0.1.0"
+        assert str(version4) == "1.2.3.0"  # Full version preserved
+        
+        print(f"\n✅ Version comparison tests passed")
+        print(f"   version1={version1}, version2={version2}")
+        print(f"   version1 > version2: {version1 > version2}")
+
+
+if __name__ == "__main__":
+    print("\n" + "="*60)
+    print("pyseekdb - Tests for detect_db_type_and_version")
+    print("="*60)
+    print(f"\nEnvironment Variable Configuration:")
+    print(f"  Server mode: {SERVER_USER}@{SERVER_HOST}:{SERVER_PORT}/{SERVER_DATABASE}")
+    print(f"  OceanBase mode: {OB_USER}@{OB_TENANT} -> {OB_HOST}:{OB_PORT}/{OB_DATABASE}")
+    print("="*60 + "\n")
+    
+    pytest.main([__file__, "-v", "-s"])
+


### PR DESCRIPTION
- Add test_detect_db_basic.py with basic functionality tests
- Test SeekDB and OceanBase server detection
- Test connection establishment and return format validation

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Supports database type and version judgment for seekdk and oceanbase
Close #71 


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
