### PR TITLE
use hex string to improve performance

### DIFF
--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -127,7 +127,7 @@ def _embedding_to_hexstring(embedding: List[float]) -> str:
     # Pack as binary (float32 for compactness, common in vector DBs)
     binary = struct.pack(f"<{len(embedding)}f", *embedding)
     hexstr = binary.hex()
-    return f'X"{hexstr}"'
+    return f"X'{hexstr}'"
 
 class ClientAPI(ABC):
     """

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -4,6 +4,7 @@ Base client interface definition
 import json
 import logging
 import re
+import struct
 from abc import ABC, abstractmethod
 from typing import List, Optional, Sequence, Dict, Any, Union, TYPE_CHECKING, Tuple, Callable
 from dataclasses import dataclass
@@ -110,6 +111,23 @@ def _get_vector_index_sql(hnsw_config: HNSWConfiguration) -> str:
     Generate VECTOR INDEX SQL clause from HNSWConfiguration.
     """
     return f"WITH (DISTANCE={hnsw_config.distance}, TYPE=hnsw, LIB=vsag)"
+
+def _embedding_to_hexstring(embedding: List[float]) -> str:
+    """
+    Convert embedding (list of floats) to a hex string.
+
+    Args:
+        embedding: List of floats
+
+    Returns:
+        Hex string representing the binary serialization of all floats in the list.
+    """
+    if not embedding:
+        return ""
+    # Pack as binary (float32 for compactness, common in vector DBs)
+    binary = struct.pack(f"<{len(embedding)}f", *embedding)
+    hexstr = binary.hex()
+    return f'X"{hexstr}"'
 
 class ClientAPI(ABC):
     """
@@ -786,12 +804,8 @@ class BaseClient(BaseConnection, AdminAPI):
             
             # Process vector
             vec_val = embeddings[i] if embeddings else None
-            if vec_val is not None:
-                # Convert vector to string format: [1.0,2.0,3.0]
-                vec_str = "[" + ",".join(map(str, vec_val)) + "]"
-                vec_sql = f"'{vec_str}'"
-            else:
-                vec_sql = "NULL"
+            vec_sql = "NULL" if vec_val is None else _embedding_to_hexstring(vec_val)
+
             
             values_list.append(f"({id_sql}, {doc_sql}, {meta_sql}, {vec_sql})")
         

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -1091,8 +1091,8 @@ class BaseClient(BaseConnection, AdminAPI):
                     set_clauses.append(f"{CollectionFieldNames.METADATA} = '{meta_json_escaped}'")
                 
                 if vec_val is not None:
-                    vec_str = "[" + ",".join(map(str, final_vector)) + "]" if final_vector else "NULL"
-                    set_clauses.append(f"{CollectionFieldNames.EMBEDDING} = '{vec_str}'")
+                    vec_str = _embedding_to_hexstring(final_vector) if final_vector else "NULL"
+                    set_clauses.append(f"{CollectionFieldNames.EMBEDDING} = {vec_str}")
                 
                 if set_clauses:
                     sql = f"UPDATE `{table_name}` SET {', '.join(set_clauses)} WHERE {CollectionFieldNames.ID} = {id_sql}"
@@ -1112,13 +1112,9 @@ class BaseClient(BaseConnection, AdminAPI):
                     meta_sql = f"'{meta_json_escaped}'"
                 else:
                     meta_sql = "NULL"
-                
-                if vec_val is not None:
-                    vec_str = "[" + ",".join(map(str, vec_val)) + "]"
-                    vec_sql = f"'{vec_str}'"
-                else:
-                    vec_sql = "NULL"
-                
+
+                vec_sql = "NULL" if vec_val is None else _embedding_to_hexstring(vec_val)
+
                 sql = f"""INSERT INTO `{table_name}` ({CollectionFieldNames.ID}, {CollectionFieldNames.DOCUMENT}, {CollectionFieldNames.METADATA}, {CollectionFieldNames.EMBEDDING}) 
                          VALUES ({id_sql}, {doc_sql}, {meta_sql}, {vec_sql})"""
                 logger.debug(f"Executing SQL: {sql}")
@@ -1678,18 +1674,18 @@ class BaseClient(BaseConnection, AdminAPI):
         
         for query_vector in query_embeddings:
             # Convert vector to string format for SQL
-            vector_str = "[" + ",".join(map(str, query_vector)) + "]"
+            vector_str = _embedding_to_hexstring(query_vector)
             
             # Build SQL query with vector distance calculation
             # Reference: SELECT id, vec FROM t2 ORDER BY l2_distance(vec, '[0.1, 0.2, 0.3]') APPROXIMATE LIMIT 5;
             # Need to include distance in SELECT for result processing
             # Use the appropriate distance function based on the index configuration
             sql = f"""
-                SELECT {select_clause}, 
-                       {distance_func}(embedding, '{vector_str}') AS distance
+                SELECT {select_clause},
+                       {distance_func}(embedding, {vector_str}) AS distance
                 FROM `{table_name}`
                 {where_clause}
-                ORDER BY {distance_func}(embedding, '{vector_str}')
+                ORDER BY {distance_func}(embedding, {vector_str})
                 APPROXIMATE
                 LIMIT %s
             """


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
close #79 
Use hex string instead of float number string to improve the vector parsing performance.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal vector/embedding encoding and storage used across add, upsert, and query operations for more consistent handling.
  * Made distance calculations and ordering use the new internal encoding for reliability.
  * No changes to public APIs or exported interfaces; existing integrations remain compatible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->