### PR TITLE
fix: default AdminClient() to embedded seekdb.db when no parameters

### DIFF
--- a/src/pyseekdb/client/__init__.py
+++ b/src/pyseekdb/client/__init__.py
@@ -294,12 +294,18 @@ def AdminClient(
         # No parameters provided
         from .client_seekdb_embedded import _PYLIBSEEKDB_AVAILABLE
         if _PYLIBSEEKDB_AVAILABLE:
-            raise ValueError(
-                "Must provide either path (embedded mode) or host (remote server mode) parameter"
+            # Default to embedded mode with seekdb.db in current working directory
+            default_path = os.path.abspath("seekdb.db")
+            logger.info(f"Creating embedded admin client (default): path={default_path}")
+            server = SeekdbEmbeddedClient(
+                path=default_path,
+                database="information_schema",  # Use system database for admin operations
+                **kwargs
             )
         else:
             raise ValueError(
-                "Must provide host (remote server mode) parameter"
+                "Default embedded mode is not available because pylibseekdb could not be imported. "
+                "Please provide host/port parameters to use RemoteServerClient."
             )
 
     # Return AdminClient proxy (only exposes database operations)


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Add logic:
- When no path/host is provided and pylibseekdb is available,
  AdminClient now defaults to embedded mode with path=os.path.abspath("seekdb.db")
  and database=information_schema, aligning with Client behavior.
- If embedded is unavailable, still require host/port.
fix #78 
## Solution Description
<!-- Please clearly and concisely describe your solution. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AdminClient now defaults to embedded mode, using seekdb.db in the current directory when neither path nor host is provided
  * Error messages enhanced to guide users on specifying host/port parameters when needed
  * Logging improved with path and server details for admin client initialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->