### PR TITLE
docs: remove redundant collection.describe() from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,10 +937,6 @@ results = collection.hybrid_search(hs)
 count = collection.count()
 print(f"Collection has {count} items")
 
-# Get detailed collection information
-info = collection.describe()
-print(f"Name: {info['name']}, Dimension: {info['dimension']}")
-
 # Preview first few items in collection (returns all columns by default)
 preview = collection.peek(limit=5)
 for i in range(len(preview["ids"])):
@@ -954,7 +950,6 @@ print(f"Database has {collection_count} collections")
 
 **Methods:**
 - `collection.count()` - Get the number of items in the collection
-- `collection.describe()` - Get detailed collection information
 - `collection.peek(limit=10)` - Quickly preview the first few items in the collection
 - `client.count_collection()` - Count the number of collections in the current database
 


### PR DESCRIPTION
### What this PR does
Removes the documentation for `collection.describe()` as discussed in #81.

The method returns only basic info (`name` and `dimension`) that is already available directly via collection properties, making the separate method and example unnecessary.

### Changes
- Deleted the code example using `collection.describe()`
- Removed the method from the list in section 5.5

### Related Issue
Closes #81

Thanks for maintaining a clean and beginner-friendly SDK!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed documentation references to a collection method from the README.
  * Deleted the corresponding example demonstrating the method's usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->