### PR TITLE
refactor: use CollectionNames helper instead of hardcoded table names

### DIFF
--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -483,7 +483,7 @@ class BaseClient(BaseConnection, AdminAPI):
         fulltext_config = _extract_fulltext_config(configuration)
         fulltext_index_clause = _get_fulltext_index_sql(fulltext_config)
 
-        # Construct table name: c$v1${name}
+        # Construct table name
         table_name = CollectionNames.table_name(name)
 
         # Construct CREATE TABLE SQL statement with HEAP organization
@@ -529,7 +529,7 @@ class BaseClient(BaseConnection, AdminAPI):
         Raises:
             ValueError: If collection does not exist
         """
-        # Construct table name: c$v1${name}
+        # Construct table name
         table_name = CollectionNames.table_name(name)
         
         # Check if table exists by describing it
@@ -617,7 +617,7 @@ class BaseClient(BaseConnection, AdminAPI):
         Raises:
             ValueError: If collection does not exist
         """
-        # Construct table name: c$v1${name}
+        # Construct table name
         table_name = CollectionNames.table_name(name)
         
         # Check if table exists first
@@ -634,10 +634,11 @@ class BaseClient(BaseConnection, AdminAPI):
         Returns:
             List of Collection objects
         """
-        # List all tables that start with 'c$v1'
-        # Use SHOW TABLES LIKE 'c$v1%' to filter collection tables
+        # List all tables that start with collection prefix
+        # Use SHOW TABLES LIKE pattern to filter collection tables
+        pattern = CollectionNames.table_pattern()
         try:
-            tables = self._execute("SHOW TABLES LIKE 'c$v1$%'")
+            tables = self._execute(f"SHOW TABLES LIKE '{pattern}'")
         except Exception:
             # Fallback: try to query information_schema
             try:
@@ -647,7 +648,7 @@ class BaseClient(BaseConnection, AdminAPI):
                     db_name = db_result[0][0] if isinstance(db_result[0], (tuple, list)) else db_result[0].get('DATABASE()', '')
                     tables = self._execute(
                         f"SELECT TABLE_NAME FROM information_schema.TABLES "
-                        f"WHERE TABLE_SCHEMA = '{db_name}' AND TABLE_NAME LIKE 'c$v1$%'"
+                        f"WHERE TABLE_SCHEMA = '{db_name}' AND TABLE_NAME LIKE '{pattern}'"
                     )
                 else:
                     return []
@@ -666,9 +667,9 @@ class BaseClient(BaseConnection, AdminAPI):
             else:
                 table_name = str(row)
             
-            # Extract collection name from table name (remove 'c$v1$' prefix)
-            if table_name.startswith('c$v1$'):
-                collection_name = table_name[5:]  # Remove 'c$v1$' prefix
+            # Extract collection name from table name
+            if CollectionNames.is_collection_table(table_name):
+                collection_name = CollectionNames.collection_name(table_name)
                 
                 # Get collection with dimension
                 try:
@@ -704,7 +705,7 @@ class BaseClient(BaseConnection, AdminAPI):
         Returns:
             True if exists, False otherwise
         """
-        # Construct table name: c$v1${name}
+        # Construct table name
         table_name = CollectionNames.table_name(name)
         
         # Check if table exists
@@ -1700,7 +1701,7 @@ class BaseClient(BaseConnection, AdminAPI):
         conn = self._ensure_connection()
         
         # Convert collection name to table name
-        table_name = f"c$v1${collection_name}"
+        table_name = CollectionNames.table_name(collection_name)
         
         # Handle vector generation logic:
         # 1. If query_embeddings are provided, use them directly without embedding
@@ -1886,7 +1887,7 @@ class BaseClient(BaseConnection, AdminAPI):
         conn = self._ensure_connection()
         
         # Convert collection name to table name
-        table_name = f"c$v1${collection_name}"
+        table_name = CollectionNames.table_name(collection_name)
         
         # Set defaults
         if limit is None:
@@ -2028,7 +2029,7 @@ class BaseClient(BaseConnection, AdminAPI):
         conn = self._ensure_connection()
         
         # Build table name
-        table_name = f"c$v1${collection_name}"
+        table_name = CollectionNames.table_name(collection_name)
         
         # Build search_parm JSON
         search_parm = self._build_search_parm(query, knn, rank, n_results, dimension=dimension, **kwargs)

--- a/src/pyseekdb/client/meta_info.py
+++ b/src/pyseekdb/client/meta_info.py
@@ -10,6 +10,32 @@ class CollectionFieldNames:
     ALL_FIELDS = [ID, DOCUMENT, EMBEDDING, METADATA]
 
 class CollectionNames:
+    # Version prefix for collection tables
+    _PREFIX = "c$v1$"
+    
     @staticmethod
     def table_name(collection_name: str) -> str:
-        return f"c$v1${collection_name}"
+        """Convert collection name to table name."""
+        return f"{CollectionNames._PREFIX}{collection_name}"
+    
+    @staticmethod
+    def collection_name(table_name: str) -> str:
+        """Extract collection name from table name."""
+        if table_name.startswith(CollectionNames._PREFIX):
+            return table_name[len(CollectionNames._PREFIX):]
+        return table_name
+    
+    @staticmethod
+    def is_collection_table(table_name: str) -> bool:
+        """Check if a table name is a collection table."""
+        return table_name.startswith(CollectionNames._PREFIX)
+    
+    @staticmethod
+    def table_pattern() -> str:
+        """Get SQL LIKE pattern for collection tables."""
+        return f"{CollectionNames._PREFIX}%"
+    
+    @staticmethod
+    def prefix() -> str:
+        """Get the collection table prefix."""
+        return CollectionNames._PREFIX

--- a/tests/integration_tests/test_client_creation.py
+++ b/tests/integration_tests/test_client_creation.py
@@ -68,7 +68,8 @@ class TestClientCreationRefactored:
         assert actual_dimension > 0, f"Collection dimension should be positive, got {actual_dimension}"
         
         # Verify table was created by checking if it exists
-        table_name = f"c$v1${test_collection_name}"
+        from pyseekdb.client.meta_info import CollectionNames
+        table_name = CollectionNames.table_name(test_collection_name)
         try:
             # Try to describe table structure to verify it exists
             table_info = db_client._server._execute(f"DESCRIBE `{table_name}`")

--- a/tests/integration_tests/test_collection_get.py
+++ b/tests/integration_tests/test_collection_get.py
@@ -42,7 +42,8 @@ class TestCollectionGet:
     
     def _insert_test_data(self, client, collection_name: str):
         """Helper method to insert test data and return inserted IDs"""
-        table_name = f"c$v1${collection_name}"
+        from pyseekdb.client.meta_info import CollectionNames
+        table_name = CollectionNames.table_name(collection_name)
         
         # Insert test data with vectors, documents, and metadata
         test_data = [

--- a/tests/integration_tests/test_collection_hybrid_search.py
+++ b/tests/integration_tests/test_collection_hybrid_search.py
@@ -41,7 +41,8 @@ class TestCollectionHybridSearchRefactored:
     
     def _insert_test_data(self, client, collection_name: str, dimension: int = 3):
         """Helper method to insert test data via SQL and return inserted IDs"""
-        table_name = f"c$v1${collection_name}"
+        from pyseekdb.client.meta_info import CollectionNames
+        table_name = CollectionNames.table_name(collection_name)
         
         base_vectors = [
             [1.0, 2.0, 3.0],

--- a/tests/integration_tests/test_collection_hybrid_search_builder_integration.py
+++ b/tests/integration_tests/test_collection_hybrid_search_builder_integration.py
@@ -55,7 +55,8 @@ class TestCollectionHybridSearchWithBuilderRefactored:
         return extended[:dimension]
 
     def _insert_test_data(self, client, collection_name: str, dimension: int = 3):
-        table_name = f"c$v1${collection_name}"
+        from pyseekdb.client.meta_info import CollectionNames
+        table_name = CollectionNames.table_name(collection_name)
         base_vectors = [
             [1.0, 2.0, 3.0],
             [2.0, 3.0, 4.0],

--- a/tests/integration_tests/test_collection_query.py
+++ b/tests/integration_tests/test_collection_query.py
@@ -21,7 +21,8 @@ class TestCollectionQueryRefactored:
             collection_name: Collection name
             dimension: Actual dimension of the collection (used to generate vectors)
         """
-        table_name = f"c$v1${collection_name}"
+        from pyseekdb.client.meta_info import CollectionNames
+        table_name = CollectionNames.table_name(collection_name)
         
         # Base vectors (3D) - will be extended or truncated to match actual dimension
         base_vectors = [

--- a/tests/integration_tests/test_fulltext_parser_config.py
+++ b/tests/integration_tests/test_fulltext_parser_config.py
@@ -114,7 +114,8 @@ class TestFulltextParserConfigRefactored:
 
         assert collection is not None
 
-        # Verify default parser (ik) is used  
+        # Verify default parser (ik) is used
+        from pyseekdb.client.meta_info import CollectionNames
         table_name = CollectionNames.table_name(test_collection_name)
         try:
             create_table_result = client._server._execute(f"SHOW CREATE TABLE `{table_name}`")
@@ -154,6 +155,7 @@ class TestFulltextParserConfigRefactored:
         assert collection is not None
 
         # Verify default parser (ik) is used for backward compatibility
+        from pyseekdb.client.meta_info import CollectionNames
         table_name = CollectionNames.table_name(test_collection_name)
         try:
             create_table_result = client._server._execute(f"SHOW CREATE TABLE `{table_name}`")

--- a/tests/integration_tests/test_fulltext_parser_config.py
+++ b/tests/integration_tests/test_fulltext_parser_config.py
@@ -47,7 +47,8 @@ class TestFulltextParserConfigRefactored:
         assert collection.dimension == test_dimension
 
         # Verify the fulltext index was created with correct parser
-        table_name = f"c$v1${test_collection_name}"
+        from pyseekdb.client.meta_info import CollectionNames
+        table_name = CollectionNames.table_name(test_collection_name)
         try:
             # Get CREATE TABLE statement
             create_table_result = client._server._execute(f"SHOW CREATE TABLE `{table_name}`")
@@ -113,8 +114,8 @@ class TestFulltextParserConfigRefactored:
 
         assert collection is not None
 
-        # Verify default parser (ik) is used
-        table_name = f"c$v1${test_collection_name}"
+        # Verify default parser (ik) is used  
+        table_name = CollectionNames.table_name(test_collection_name)
         try:
             create_table_result = client._server._execute(f"SHOW CREATE TABLE `{table_name}`")
             create_stmt = create_table_result[0][1] if isinstance(create_table_result[0], (tuple, list)) else \
@@ -153,7 +154,7 @@ class TestFulltextParserConfigRefactored:
         assert collection is not None
 
         # Verify default parser (ik) is used for backward compatibility
-        table_name = f"c$v1${test_collection_name}"
+        table_name = CollectionNames.table_name(test_collection_name)
         try:
             create_table_result = client._server._execute(f"SHOW CREATE TABLE `{table_name}`")
             create_stmt = create_table_result[0][1] if isinstance(create_table_result[0], (tuple, list)) else \


### PR DESCRIPTION
## Summary
Closes #82

## Solution Description
- Moved that hardcoded `"c$v1$"` into a `_PREFIX` constant 
- Enhanced the CollectionNames class, added some helper methods
- Replaced all the hardcoded stuff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and standardized collection table naming and lookup across the client for consistent behavior.

* **Tests**
  * Updated integration tests to use the centralized naming utilities for more reliable verification.

*No user-facing changes in this release.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->