### PR TITLE
fix: Validate collection names

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ collection = client.get_or_create_collection(
 ```
 
 **Parameters:**
-- `name` (str): Collection name (required). Must be non-empty, use only letters/digits/underscore (`[a-zA-Z0-9_]`), and its length must fit within the underlying table name limit after adding the collection prefix (for the default `c$v1$` prefix on seekdb/OceanBase, this is typically up to 59 characters).
+- `name` (str): Collection name (required). Must be non-empty, use only letters/digits/underscore (`[a-zA-Z0-9_]`), and be at most 512 characters.
 - `configuration` (Configuration, HNSWConfiguration, or None, optional): Index configuration
   - **Recommended:** `Configuration` - Wrapper class that can include both `HNSWConfiguration` and `FulltextParserConfig`
     - Use `Configuration(hnsw=HNSWConfiguration(...))` even when only vector index config is needed

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ collection = client.get_or_create_collection(
 ```
 
 **Parameters:**
-- `name` (str): Collection name (required). Must be 1–512 characters and contain only letters, digits, or underscores (`[a-zA-Z0-9_]`).
+- `name` (str): Collection name (required). Must be non-empty, use only letters/digits/underscore (`[a-zA-Z0-9_]`), and its length must fit within the underlying table name limit after adding the collection prefix (for the default `c$v1$` prefix on seekdb/OceanBase, this is typically up to 59 characters).
 - `configuration` (Configuration, HNSWConfiguration, or None, optional): Index configuration
   - **Recommended:** `Configuration` - Wrapper class that can include both `HNSWConfiguration` and `FulltextParserConfig`
     - Use `Configuration(hnsw=HNSWConfiguration(...))` even when only vector index config is needed

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ collection = client.get_or_create_collection(
 ```
 
 **Parameters:**
-- `name` (str): Collection name (required)
+- `name` (str): Collection name (required). Must be 1–512 characters and contain only letters, digits, or underscores (`[a-zA-Z0-9_]`).
 - `configuration` (Configuration, HNSWConfiguration, or None, optional): Index configuration
   - **Recommended:** `Configuration` - Wrapper class that can include both `HNSWConfiguration` and `FulltextParserConfig`
     - Use `Configuration(hnsw=HNSWConfiguration(...))` even when only vector index config is needed

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -41,7 +41,17 @@ from .database import Database
 EmbeddingFunctionParam = Union[EmbeddingFunction[EmbeddingDocuments], None, Any]
 
 _COLLECTION_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
+
+# Logical maximum collection name length exposed by the Python API.
+# The effective maximum may be lower depending on the underlying database
+# table name length limit and the configured collection table prefix.
 _MAX_COLLECTION_NAME_LENGTH = 512
+
+# Current seekdb/OceanBase table name length limit is 64 characters.
+# We subtract the collection table prefix length from this value when
+# validating collection names so that the generated table name stays
+# within the database constraint.
+_MAX_TABLE_NAME_LENGTH = 64
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +97,11 @@ def _validate_collection_name(name: str) -> None:
 
     Rules:
     - Type must be str
-    - 1 to 512 characters
+    - Length between 1 and the effective maximum, where:
+      effective_max = min(
+          _MAX_COLLECTION_NAME_LENGTH,
+          _MAX_TABLE_NAME_LENGTH - len(CollectionNames.table_name(""))
+      )
     - Only [a-zA-Z0-9_]
 
     Raises:
@@ -98,10 +112,20 @@ def _validate_collection_name(name: str) -> None:
         raise TypeError(f"Collection name must be a string, got {type(name).__name__}")
     if not name:
         raise ValueError("Collection name must not be empty")
-    if len(name) > _MAX_COLLECTION_NAME_LENGTH:
+    # Calculate effective maximum based on table prefix and database limit
+    table_prefix = CollectionNames.table_name("")
+    # Guard against misconfiguration where prefix itself is too long
+    available_length = max(0, _MAX_TABLE_NAME_LENGTH - len(table_prefix))
+    effective_max = min(_MAX_COLLECTION_NAME_LENGTH, available_length)
+    if effective_max <= 0:
+        raise ValueError(
+            "Invalid collection table prefix configuration: no space left for collection name. "
+            f"Prefix={table_prefix!r}, table name limit={_MAX_TABLE_NAME_LENGTH}."
+        )
+    if len(name) > effective_max:
         raise ValueError(
             f"Collection name too long: {len(name)} characters; "
-            f"maximum allowed is {_MAX_COLLECTION_NAME_LENGTH}"
+            f"maximum allowed is {effective_max} for the current prefix."
         )
     if _COLLECTION_NAME_PATTERN.match(name) is None:
         raise ValueError(

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -6,15 +6,14 @@ import logging
 import re
 import struct
 from abc import ABC, abstractmethod
-from typing import List, Optional, Sequence, Dict, Any, Union, TYPE_CHECKING, Tuple, Callable
+from typing import List, Optional, Dict, Any, Union, TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     from .version import Version
-from dataclasses import dataclass
 from pymysql.converters import escape_string
 
 from .base_connection import BaseConnection
-from .admin_client import AdminAPI, DEFAULT_TENANT
+from .admin_client import AdminAPI
 from .meta_info import CollectionNames, CollectionFieldNames
 from .filters import FilterBuilder
 from .configuration import (
@@ -27,26 +26,20 @@ from .configuration import (
 )
 from .embedding_function import (
     EmbeddingFunction,
-    DefaultEmbeddingFunction,
     get_default_embedding_function,
-    Documents as EmbeddingDocuments,
-    Embeddings as EmbeddingVectors
+    Documents as EmbeddingDocuments
 )
 
 from .collection import Collection
 
-from .database import Database
 
 # Type alias for embedding_function parameter that can be EmbeddingFunction, None, or sentinel
 EmbeddingFunctionParam = Union[EmbeddingFunction[EmbeddingDocuments], None, Any]
 
 _COLLECTION_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
 
-# Current seekdb/OceanBase table name length limit is 64 characters.
-# We subtract the collection table prefix length from this value when
-# validating collection names so that the generated table name stays
-# within the database constraint.
-_MAX_TABLE_NAME_LENGTH = 64
+# Maximum allowed length for user-facing collection names.
+_MAX_COLLECTION_NAME_LENGTH = 512
 
 logger = logging.getLogger(__name__)
 
@@ -92,8 +85,7 @@ def _validate_collection_name(name: str) -> None:
 
     Rules:
     - Type must be str
-    - Length between 1 and the effective maximum, where:
-      effective_max = _MAX_TABLE_NAME_LENGTH - len(CollectionNames.table_name(""))
+    - Length between 1 and _MAX_COLLECTION_NAME_LENGTH
     - Only [a-zA-Z0-9_]
 
     Raises:
@@ -104,20 +96,10 @@ def _validate_collection_name(name: str) -> None:
         raise TypeError(f"Collection name must be a string, got {type(name).__name__}")
     if not name:
         raise ValueError("Collection name must not be empty")
-    # Calculate effective maximum based on table prefix and database limit
-    table_prefix = CollectionNames.table_name("")
-    # Guard against misconfiguration where prefix itself is too long
-    available_length = max(0, _MAX_TABLE_NAME_LENGTH - len(table_prefix))
-    effective_max = available_length
-    if effective_max <= 0:
-        raise ValueError(
-            "Invalid collection table prefix configuration: no space left for collection name. "
-            f"Prefix={table_prefix!r}, table name limit={_MAX_TABLE_NAME_LENGTH}."
-        )
-    if len(name) > effective_max:
+    if len(name) > _MAX_COLLECTION_NAME_LENGTH:
         raise ValueError(
             f"Collection name too long: {len(name)} characters; "
-            f"maximum allowed is {effective_max} for the current prefix."
+            f"maximum allowed is {_MAX_COLLECTION_NAME_LENGTH}."
         )
     if _COLLECTION_NAME_PATTERN.match(name) is None:
         raise ValueError(
@@ -2100,7 +2082,7 @@ class BaseClient(BaseConnection, AdminAPI):
         rows = self._execute_query_with_cursor(conn, get_sql_query, [], use_context_manager)
         
         if not rows or not rows[0].get("query_sql"):
-            logger.warning(f"No SQL query returned from GET_SQL")
+            logger.warning("No SQL query returned from GET_SQL")
             return {
                 "ids": [[]],
                 "distances": [[]],

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -40,6 +40,9 @@ from .database import Database
 # Type alias for embedding_function parameter that can be EmbeddingFunction, None, or sentinel
 EmbeddingFunctionParam = Union[EmbeddingFunction[EmbeddingDocuments], None, Any]
 
+_COLLECTION_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
+_MAX_COLLECTION_NAME_LENGTH = 512
+
 logger = logging.getLogger(__name__)
 
 # Sentinel object to distinguish between "parameter not provided" and "explicitly set to None"
@@ -76,6 +79,35 @@ def _extract_fulltext_config(config: ConfigurationParam) -> Optional[FulltextPar
     else:
         # Should not reach here due to type checking, but handle gracefully
         return None
+
+
+def _validate_collection_name(name: str) -> None:
+    """
+    Validate collection name against allowed charset and length constraints.
+
+    Rules:
+    - Type must be str
+    - 1 to 512 characters
+    - Only [a-zA-Z0-9_]
+
+    Raises:
+        TypeError: If name is not a string.
+        ValueError: If name is empty, too long, or contains invalid characters.
+    """
+    if not isinstance(name, str):
+        raise TypeError(f"Collection name must be a string, got {type(name).__name__}")
+    if not name:
+        raise ValueError("Collection name must not be empty")
+    if len(name) > _MAX_COLLECTION_NAME_LENGTH:
+        raise ValueError(
+            f"Collection name too long: {len(name)} characters; "
+            f"maximum allowed is {_MAX_COLLECTION_NAME_LENGTH}"
+        )
+    if _COLLECTION_NAME_PATTERN.match(name) is None:
+        raise ValueError(
+            "Collection name contains invalid characters. "
+            "Only letters, digits, and underscore are allowed: [a-zA-Z0-9_]"
+        )
 
 
 def _get_fulltext_index_sql(fulltext_config: Optional[FulltextParserConfig] = None) -> str:
@@ -384,6 +416,7 @@ class BaseClient(BaseConnection, AdminAPI):
             >>> config = HNSWConfiguration(dimension=128, distance='cosine')
             >>> collection = client.create_collection('my_collection', configuration=config, embedding_function=None)
         """
+        _validate_collection_name(name)
         # Handle embedding function first
         # If not provided (sentinel), use default embedding function
         if embedding_function is _NOT_PROVIDED:
@@ -742,12 +775,15 @@ class BaseClient(BaseConnection, AdminAPI):
                        embedding_function is also None (cannot determine dimension), or if embedding_function
                        is provided and configuration.dimension doesn't match the calculated dimension
         """
+        # Validate collection name before any database interaction
+        _validate_collection_name(name)
+
         # First, try to get the collection
         if self.has_collection(name):
             # Collection exists, return it
             # Pass embedding_function (could be _NOT_PROVIDED, None, or an EmbeddingFunction instance)
             return self.get_collection(name, embedding_function=embedding_function)
-        
+
         # Collection doesn't exist, create it with provided or default configuration
         return self.create_collection(
             name=name,

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -42,11 +42,6 @@ EmbeddingFunctionParam = Union[EmbeddingFunction[EmbeddingDocuments], None, Any]
 
 _COLLECTION_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
 
-# Logical maximum collection name length exposed by the Python API.
-# The effective maximum may be lower depending on the underlying database
-# table name length limit and the configured collection table prefix.
-_MAX_COLLECTION_NAME_LENGTH = 512
-
 # Current seekdb/OceanBase table name length limit is 64 characters.
 # We subtract the collection table prefix length from this value when
 # validating collection names so that the generated table name stays
@@ -98,10 +93,7 @@ def _validate_collection_name(name: str) -> None:
     Rules:
     - Type must be str
     - Length between 1 and the effective maximum, where:
-      effective_max = min(
-          _MAX_COLLECTION_NAME_LENGTH,
-          _MAX_TABLE_NAME_LENGTH - len(CollectionNames.table_name(""))
-      )
+      effective_max = _MAX_TABLE_NAME_LENGTH - len(CollectionNames.table_name(""))
     - Only [a-zA-Z0-9_]
 
     Raises:
@@ -116,7 +108,7 @@ def _validate_collection_name(name: str) -> None:
     table_prefix = CollectionNames.table_name("")
     # Guard against misconfiguration where prefix itself is too long
     available_length = max(0, _MAX_TABLE_NAME_LENGTH - len(table_prefix))
-    effective_max = min(_MAX_COLLECTION_NAME_LENGTH, available_length)
+    effective_max = available_length
     if effective_max <= 0:
         raise ValueError(
             "Invalid collection table prefix configuration: no space left for collection name. "

--- a/tests/unit_tests/test_collection_name_validation.py
+++ b/tests/unit_tests/test_collection_name_validation.py
@@ -5,9 +5,11 @@ import pytest
 import sys
 from pathlib import Path
 
-# Ensure project root is on sys.path so we can import pyseekdb from source
+# Ensure local src/ is on sys.path so we import the in-repo pyseekdb,
+# not an already-installed version in the virtualenv.
 project_root = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(project_root))
+src_root = project_root / "src"
+sys.path.insert(0, str(src_root))
 
 from pyseekdb.client.client_base import _validate_collection_name  # type: ignore
 from pyseekdb.client.meta_info import CollectionNames

--- a/tests/unit_tests/test_collection_name_validation.py
+++ b/tests/unit_tests/test_collection_name_validation.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for collection name validation.
+"""
+import pytest
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path so we can import pyseekdb from source
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from pyseekdb.client.client_base import _validate_collection_name  # type: ignore
+
+
+class TestCollectionNameValidation:
+    """Tests for collection name constraints."""
+
+    def test_valid_names(self):
+        """Names with allowed characters and length should pass."""
+        valid_names = [
+            "a",
+            "A",
+            "0",
+            "collection_1",
+            "MyCollection_123",
+            "A" * 512,
+        ]
+        for name in valid_names:
+            _validate_collection_name(name)
+
+    def test_invalid_type(self):
+        """Non-string names should raise TypeError."""
+        with pytest.raises(TypeError):
+            _validate_collection_name(123)  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            _validate_collection_name(None)  # type: ignore[arg-type]
+
+    def test_empty_name(self):
+        """Empty string should be rejected."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_collection_name("")
+
+    def test_name_too_long(self):
+        """Names longer than 512 characters should be rejected."""
+        long_name = "a" * 513
+        with pytest.raises(ValueError, match="maximum allowed is 512"):
+            _validate_collection_name(long_name)
+
+    def test_invalid_characters(self):
+        """Names with characters outside [a-zA-Z0-9_] should be rejected."""
+        invalid_names = [
+            "name-with-dash",
+            "name.with.dot",
+            "name with space",
+            "name$",
+            "名字",
+        ]
+        for name in invalid_names:
+            with pytest.raises(ValueError, match="Only letters, digits, and underscore"):
+                _validate_collection_name(name)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+

--- a/tests/unit_tests/test_collection_name_validation.py
+++ b/tests/unit_tests/test_collection_name_validation.py
@@ -21,14 +21,11 @@ class TestCollectionNameValidation:
     @property
     def _effective_max_length(self) -> int:
         """
-        Calculate effective maximum name length based on current prefix and
-        database table name limit used in client_base.
+        Return maximum allowed collection name length from client_base.
         """
-        from pyseekdb.client.client_base import _MAX_TABLE_NAME_LENGTH  # type: ignore
+        from pyseekdb.client.client_base import _MAX_COLLECTION_NAME_LENGTH  # type: ignore
 
-        prefix = CollectionNames.table_name("")
-        available = max(0, _MAX_TABLE_NAME_LENGTH - len(prefix))
-        return available
+        return _MAX_COLLECTION_NAME_LENGTH
 
     def test_valid_names(self):
         """Names with allowed characters and length should pass."""

--- a/tests/unit_tests/test_collection_name_validation.py
+++ b/tests/unit_tests/test_collection_name_validation.py
@@ -10,20 +10,37 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from pyseekdb.client.client_base import _validate_collection_name  # type: ignore
+from pyseekdb.client.meta_info import CollectionNames
 
 
 class TestCollectionNameValidation:
     """Tests for collection name constraints."""
 
+    @property
+    def _effective_max_length(self) -> int:
+        """
+        Calculate effective maximum name length based on current prefix and
+        database table name limit used in client_base.
+        """
+        from pyseekdb.client.client_base import (  # type: ignore
+            _MAX_COLLECTION_NAME_LENGTH,
+            _MAX_TABLE_NAME_LENGTH,
+        )
+
+        prefix = CollectionNames.table_name("")
+        available = max(0, _MAX_TABLE_NAME_LENGTH - len(prefix))
+        return min(_MAX_COLLECTION_NAME_LENGTH, available)
+
     def test_valid_names(self):
         """Names with allowed characters and length should pass."""
+        max_len = self._effective_max_length
         valid_names = [
             "a",
             "A",
             "0",
             "collection_1",
             "MyCollection_123",
-            "A" * 512,
+            "A" * max_len,
         ]
         for name in valid_names:
             _validate_collection_name(name)
@@ -41,9 +58,10 @@ class TestCollectionNameValidation:
             _validate_collection_name("")
 
     def test_name_too_long(self):
-        """Names longer than 512 characters should be rejected."""
-        long_name = "a" * 513
-        with pytest.raises(ValueError, match="maximum allowed is 512"):
+        """Names longer than effective maximum should be rejected."""
+        max_len = self._effective_max_length
+        long_name = "a" * (max_len + 1)
+        with pytest.raises(ValueError, match="maximum allowed is"):
             _validate_collection_name(long_name)
 
     def test_invalid_characters(self):
@@ -62,4 +80,3 @@ class TestCollectionNameValidation:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/unit_tests/test_collection_name_validation.py
+++ b/tests/unit_tests/test_collection_name_validation.py
@@ -24,14 +24,11 @@ class TestCollectionNameValidation:
         Calculate effective maximum name length based on current prefix and
         database table name limit used in client_base.
         """
-        from pyseekdb.client.client_base import (  # type: ignore
-            _MAX_COLLECTION_NAME_LENGTH,
-            _MAX_TABLE_NAME_LENGTH,
-        )
+        from pyseekdb.client.client_base import _MAX_TABLE_NAME_LENGTH  # type: ignore
 
         prefix = CollectionNames.table_name("")
         available = max(0, _MAX_TABLE_NAME_LENGTH - len(prefix))
-        return min(_MAX_COLLECTION_NAME_LENGTH, available)
+        return available
 
     def test_valid_names(self):
         """Names with allowed characters and length should pass."""


### PR DESCRIPTION


## Summary

Enforce stricter, database-aware validation for collection names in pyseekdb, ensuring that invalid names are rejected at the client layer before any SQL is executed #74 




## Solution Description
  - Added a centralized collection name validator in BaseClient:
      - Only allows [a-zA-Z0-9_].
      - Computes an effective max length based on:
          - The underlying DB table name limit (_MAX_TABLE_NAME_LENGTH = 64) minus the configurable collection table prefix from CollectionNames.table_name("").
      - For the default prefix c$v1$, this yields a safe max length (e.g. ~59 chars) so that prefix + name stays within the DB limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified collection naming rules and configuration guidance, including character restrictions, maximum length, and configuration wrapper usage.

* **New Features**
  * Enforced collection naming conventions to prevent invalid collection creation.

* **Tests**
  * Added unit tests covering collection name validation and related edge cases.

* **Other**
  * Minor clarification to a warning message for clearer diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->