### PR TITLE
fix query ids with % char

### DIFF
--- a/src/pyseekdb/client/__init__.py
+++ b/src/pyseekdb/client/__init__.py
@@ -47,6 +47,7 @@ from .hybrid_search import (
 
 logger = logging.getLogger(__name__)
 
+
 def _resolve_password(password: str) -> str:
     """Get password from env if not provided (keeps existing behavior)."""
     return password or os.environ.get("SEEKDB_PASSWORD", "")
@@ -77,9 +78,9 @@ def _create_server_client(
     """
     if path is not None:
         if is_admin:
-            logger.info(f"Creating embedded admin client: path={path}")
+            logger.debug(f"Creating embedded admin client: path={path}")
         else:
-            logger.info(f"Creating embedded client: path={path}, database={database}")
+            logger.debug(f"Creating embedded client: path={path}, database={database}")
         return SeekdbEmbeddedClient(path=path, database=database, **kwargs)
 
     if host is not None:
@@ -89,9 +90,13 @@ def _create_server_client(
         if user is None:
             user = "root"
         if is_admin:
-            logger.info(f"Creating remote server admin client: {user}@{tenant}@{host}:{port}")
+            logger.debug(
+                f"Creating remote server admin client: {user}@{tenant}@{host}:{port}"
+            )
         else:
-            logger.info(f"Creating remote server client: {user}@{tenant}@{host}:{port}/{database}")
+            logger.debug(
+                f"Creating remote server client: {user}@{tenant}@{host}:{port}/{database}"
+            )
         return RemoteServerClient(
             host=host,
             port=port,
@@ -108,15 +113,20 @@ def _create_server_client(
     if _PYLIBSEEKDB_AVAILABLE:
         default_path = _default_seekdb_path()
         if is_admin:
-            logger.info(f"Creating embedded admin client (default): path={default_path}")
+            logger.debug(
+                f"Creating embedded admin client (default): path={default_path}"
+            )
         else:
-            logger.info(f"Creating embedded client (default): path={default_path}, database={database}")
+            logger.debug(
+                f"Creating embedded client (default): path={default_path}, database={database}"
+            )
         return SeekdbEmbeddedClient(path=default_path, database=database, **kwargs)
 
     raise ValueError(
         "Default embedded mode is not available because pylibseekdb could not be imported. "
         "Please provide host/port parameters to use RemoteServerClient."
     )
+
 
 __all__ = [
     "BaseConnection",

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -1878,7 +1878,7 @@ class BaseClient(BaseConnection, AdminAPI):
         """
         Convert ID to SQL format for varbinary(512) _id field with parameters
         """
-        return f"CAST(%s AS BINARY)", escape_string(id_val)
+        return f"CAST(%s AS BINARY)", (id_val)
 
     def _convert_id_from_bytes(self, record_id: Any) -> str:
         """

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -1794,7 +1794,9 @@ class BaseClient(BaseConnection, AdminAPI):
             for id_val in id_list:
                 if not isinstance(id_val, str):
                     id_val = str(id_val)
-                processed_ids.append(self._convert_id_to_sql(id_val))
+                id_sql, id_param = self._convert_id_to_sql_with_paramters(id_val)
+                processed_ids.append(id_sql)
+                params.append(id_param)
 
             where_clauses.append(f"_id IN ({','.join(processed_ids)})")
 
@@ -1857,6 +1859,12 @@ class BaseClient(BaseConnection, AdminAPI):
         id_val_escaped = escape_string(id_val)
         # Use CAST to convert string to binary for varbinary(512) field
         return f"CAST('{id_val_escaped}' AS BINARY)"
+
+    def _convert_id_to_sql_with_paramters(self, id_val: str) -> (str, str):
+        """
+        Convert ID to SQL format for varbinary(512) _id field with parameters
+        """
+        return f"CAST(%s AS BINARY)", escape_string(id_val)
 
     def _convert_id_from_bytes(self, record_id: Any) -> str:
         """
@@ -2318,7 +2326,7 @@ class BaseClient(BaseConnection, AdminAPI):
         if "embeddings" in include_fields:
             result["embeddings"] = result_embeddings
 
-        logger.info(
+        logger.debug(
             f"✅ Get completed for '{collection_name}', found {len(result_ids)} results"
         )
         return result

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -366,8 +366,7 @@ class BaseClient(BaseConnection, AdminAPI):
         return f" in tenant: {tenant}" if tenant else ""
 
     def _parse_schema_row(
-        self,
-        row: Any
+        self, row: Any
     ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         if isinstance(row, dict):
             return (
@@ -391,10 +390,14 @@ class BaseClient(BaseConnection, AdminAPI):
             tenant: tenant name (for OceanBase)
         """
         effective_tenant = self._database_tenant(tenant)
-        logger.debug(f"Creating database: {name}{self._database_context(effective_tenant)}")
+        logger.debug(
+            f"Creating database: {name}{self._database_context(effective_tenant)}"
+        )
         sql = f"CREATE DATABASE IF NOT EXISTS `{name}`"
         self._execute(sql)
-        logger.debug(f"✅ Database created: {name}{self._database_context(effective_tenant)}")
+        logger.debug(
+            f"✅ Database created: {name}{self._database_context(effective_tenant)}"
+        )
 
     def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
         """
@@ -405,7 +408,9 @@ class BaseClient(BaseConnection, AdminAPI):
             tenant: tenant name (for OceanBase)
         """
         effective_tenant = self._database_tenant(tenant)
-        logger.debug(f"Getting database: {name}{self._database_context(effective_tenant)}")
+        logger.debug(
+            f"Getting database: {name}{self._database_context(effective_tenant)}"
+        )
         sql = (
             "SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME "
             "FROM information_schema.SCHEMATA "
@@ -436,16 +441,20 @@ class BaseClient(BaseConnection, AdminAPI):
             tenant: tenant name (for OceanBase)
         """
         effective_tenant = self._database_tenant(tenant)
-        logger.debug(f"Deleting database: {name}{self._database_context(effective_tenant)}")
+        logger.debug(
+            f"Deleting database: {name}{self._database_context(effective_tenant)}"
+        )
         sql = f"DROP DATABASE IF EXISTS `{name}`"
         self._execute(sql)
-        logger.debug(f"✅ Database deleted: {name}{self._database_context(effective_tenant)}")
+        logger.debug(
+            f"✅ Database deleted: {name}{self._database_context(effective_tenant)}"
+        )
 
     def list_databases(
         self,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        tenant: str = DEFAULT_TENANT
+        tenant: str = DEFAULT_TENANT,
     ) -> Sequence[Database]:
         """
         List all databases
@@ -472,15 +481,20 @@ class BaseClient(BaseConnection, AdminAPI):
             db_name, charset, collation = self._parse_schema_row(row)
             if not db_name:
                 continue
-            databases.append(Database(
-                name=db_name,
-                tenant=effective_tenant,
-                charset=charset,
-                collation=collation,
-            ))
+            databases.append(
+                Database(
+                    name=db_name,
+                    tenant=effective_tenant,
+                    charset=charset,
+                    collation=collation,
+                )
+            )
 
-        logger.debug(f"✅ Found {len(databases)} databases{self._database_context(effective_tenant)}")
+        logger.debug(
+            f"✅ Found {len(databases)} databases{self._database_context(effective_tenant)}"
+        )
         return databases
+
     # ==================== Collection Management (User-facing) ====================
 
     def create_collection(
@@ -2003,7 +2017,7 @@ class BaseClient(BaseConnection, AdminAPI):
             return None
         finally:
             cursor.close()
-    
+
     # -------------------- DQL Operations (Common Implementation) --------------------
 
     def _collection_query(

--- a/src/pyseekdb/client/client_seekdb_embedded.py
+++ b/src/pyseekdb/client/client_seekdb_embedded.py
@@ -144,7 +144,7 @@ class SeekdbEmbeddedClient(BaseClient):
             # Check if this is a query statement (SELECT, SHOW, DESCRIBE, DESC)
             # Only query statements return result sets that need fetchall()
             is_query = self._should_fetch_results(cursor, embedded_sql)
-            
+
             if not is_query:
                 # For non-query statements (DELETE, UPDATE, INSERT, etc.), return empty list
                 return []
@@ -238,7 +238,7 @@ class SeekdbEmbeddedClient(BaseClient):
             tenant: ignored for embedded mode (no tenant concept)
         """
         return super().create_database(name=name, tenant=tenant)
-    
+
     def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
         """
         Get database object (tenant parameter ignored for embedded mode)
@@ -248,7 +248,7 @@ class SeekdbEmbeddedClient(BaseClient):
             tenant: ignored for embedded mode (no tenant concept)
         """
         return super().get_database(name=name, tenant=tenant)
-    
+
     def delete_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
         """
         Delete database (tenant parameter ignored for embedded mode)
@@ -258,7 +258,7 @@ class SeekdbEmbeddedClient(BaseClient):
             tenant: ignored for embedded mode (no tenant concept)
         """
         return super().delete_database(name=name, tenant=tenant)
-    
+
     def list_databases(
         self,
         limit: Optional[int] = None,
@@ -274,7 +274,7 @@ class SeekdbEmbeddedClient(BaseClient):
             tenant: ignored for embedded mode (no tenant concept)
         """
         return super().list_databases(limit=limit, offset=offset, tenant=tenant)
-    
+
     def __repr__(self):
         status = "connected" if self.is_connected() else "disconnected"
         return f"<SeekdbEmbeddedClient path={self.path} database={self.database} status={status}>"

--- a/src/pyseekdb/client/client_seekdb_server.py
+++ b/src/pyseekdb/client/client_seekdb_server.py
@@ -97,7 +97,7 @@ class RemoteServerClient(BaseClient):
     def is_connected(self) -> bool:
         """Check connection status"""
         return self._connection is not None and self._connection.open
-    
+
     def get_raw_connection(self) -> pymysql.Connection:
         """Get raw connection object"""
         return self._ensure_connection()
@@ -146,7 +146,7 @@ class RemoteServerClient(BaseClient):
             Remote server has multi-tenant architecture. Database is scoped to client's tenant.
         """
         return super().create_database(name=name, tenant=tenant)
-    
+
     def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
         """
         Get database object (remote server has tenant concept, uses client's tenant)
@@ -162,7 +162,7 @@ class RemoteServerClient(BaseClient):
             Remote server has multi-tenant architecture. Database is scoped to client's tenant.
         """
         return super().get_database(name=name, tenant=tenant)
-    
+
     def delete_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
         """
         Delete database (remote server has tenant concept, uses client's tenant)
@@ -175,7 +175,7 @@ class RemoteServerClient(BaseClient):
             Remote server has multi-tenant architecture. Database is scoped to client's tenant.
         """
         return super().delete_database(name=name, tenant=tenant)
-    
+
     def list_databases(
         self,
         limit: Optional[int] = None,
@@ -204,7 +204,7 @@ class RemoteServerClient(BaseClient):
                 f"Specified tenant '{tenant}' differs from client tenant '{self.tenant}', using client tenant"
             )
         return self.tenant
-    
+
     def __repr__(self):
         status = "connected" if self.is_connected() else "disconnected"
         return f"<RemoteServerClient {self.full_user}@{self.host}:{self.port}/{self.database} status={status}>"

--- a/src/pyseekdb/client/embedding_function.py
+++ b/src/pyseekdb/client/embedding_function.py
@@ -21,7 +21,7 @@ from typing import (
     TypeVar,
     cast,
     Any,
-    Dict
+    Dict,
 )
 from abc import abstractmethod
 
@@ -105,6 +105,7 @@ class EmbeddingFunction(Protocol[D]):
             Note: The 'name' field is not included as it's handled by the upper layer for routing.
         """
         ...
+
 
 def dimension_of(embedding_function: EmbeddingFunction[D]) -> int:
     """

--- a/src/pyseekdb/client/sql_utils.py
+++ b/src/pyseekdb/client/sql_utils.py
@@ -8,6 +8,22 @@ from typing import Any, Sequence
 from pymysql.converters import escape_string
 
 
+def escape_percent_for_sql(value: str) -> str:
+    """
+    Escape percent signs in SQL string values to prevent format string interpretation.
+
+    When pymysql's cursor.execute() processes SQL strings, it may interpret % as format
+    specifiers. This function escapes % to %% to prevent that.
+
+    Args:
+        value: String value that may contain % characters
+
+    Returns:
+        String with % escaped as %%
+    """
+    return value.replace("%", "%%")
+
+
 def is_query_sql(sql: str) -> bool:
     if not sql:
         return False

--- a/src/pyseekdb/client/sql_utils.py
+++ b/src/pyseekdb/client/sql_utils.py
@@ -42,9 +42,7 @@ def render_sql_with_params(sql: str, params: Sequence[Any]) -> str:
     parts = sql.split("%s")
     placeholder_count = len(parts) - 1
     if placeholder_count != len(params):
-        raise ValueError(
-            f"Expected {placeholder_count} parameters, got {len(params)}"
-        )
+        raise ValueError(f"Expected {placeholder_count} parameters, got {len(params)}")
     rendered_parts = [parts[0]]
     for param, part in zip(params, parts[1:]):
         if param is None:

--- a/src/pyseekdb/utils/embedding_functions/openai_embedding_function.py
+++ b/src/pyseekdb/utils/embedding_functions/openai_embedding_function.py
@@ -159,12 +159,14 @@ class OpenAIEmbeddingFunction(OpenAIBaseEmbeddingFunction):
         dimensions = config.get("dimensions")
         client_kwargs = config.get("client_kwargs", {})
         if not isinstance(client_kwargs, dict):
-            raise ValueError(f"client_kwargs must be a dictionary, but got {client_kwargs}")
+            raise ValueError(
+                f"client_kwargs must be a dictionary, but got {client_kwargs}"
+            )
 
         return OpenAIEmbeddingFunction(
             model_name=model_name,
             api_key_env=api_key_env,
             api_base=api_base,
             dimensions=dimensions,
-            **client_kwargs
+            **client_kwargs,
         )

--- a/src/pyseekdb/utils/embedding_functions/qwen_embedding_function.py
+++ b/src/pyseekdb/utils/embedding_functions/qwen_embedding_function.py
@@ -157,12 +157,14 @@ class QwenEmbeddingFunction(OpenAIBaseEmbeddingFunction):
         dimensions = config.get("dimensions")
         client_kwargs = config.get("client_kwargs", {})
         if not isinstance(client_kwargs, dict):
-            raise ValueError(f"client_kwargs must be a dictionary, but got {client_kwargs}")
+            raise ValueError(
+                f"client_kwargs must be a dictionary, but got {client_kwargs}"
+            )
 
         return QwenEmbeddingFunction(
             model_name=model_name,
             api_key_env=api_key_env,
             api_base=api_base,
             dimensions=dimensions,
-            **client_kwargs
+            **client_kwargs,
         )

--- a/src/pyseekdb/utils/embedding_functions/sentence_transformer_embedding_function.py
+++ b/src/pyseekdb/utils/embedding_functions/sentence_transformer_embedding_function.py
@@ -111,7 +111,9 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         }
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "SentenceTransformerEmbeddingFunction":
+    def build_from_config(
+        config: Dict[str, Any],
+    ) -> "SentenceTransformerEmbeddingFunction":
         """Build a SentenceTransformerEmbeddingFunction from its configuration dictionary.
 
         Args:
@@ -134,5 +136,5 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
             model_name=model_name,
             device=device,
             normalize_embeddings=normalize_embeddings,
-            **kwargs
+            **kwargs,
         )

--- a/tests/integration_tests/test_special_characters_bugs.py
+++ b/tests/integration_tests/test_special_characters_bugs.py
@@ -1,0 +1,280 @@
+"""
+Integration tests to reproduce bugs with special characters in insert operations.
+
+Bug reports:
+1. If there's '\' character in the documents parameter, it failed to insert data into database.
+2. If there's '%' in the id parameter, it failed.
+3. If there's '"' character in the metadata parameter, it failed to insert data into database.
+"""
+
+import pytest
+import time
+import uuid
+
+import pyseekdb
+from pyseekdb import HNSWConfiguration
+
+
+class TestSpecialCharactersBugs:
+    """Test special characters handling in insert operations"""
+
+    def test_backslash_in_documents(self, db_client):
+        """
+        Bug reproduction: If there's '\' character in the documents parameter,
+        it failed to insert data into database.
+        """
+        # Create test collection
+        collection_name = f"test_backslash_doc_{int(time.time() * 1000)}"
+        dimension = 3
+
+        # Create collection using proper API
+        config = HNSWConfiguration(dimension=dimension, distance="cosine")
+        collection = db_client.create_collection(
+            name=collection_name, configuration=config, embedding_function=None
+        )
+
+        # Test cases with backslashes in documents
+        test_cases = [
+            # Single backslash
+            "Single\\backslash",
+            "\\Backslash at start",
+            "Backslash at end\\",
+
+            # Multiple consecutive backslashes
+            "Double\\\\backslash",
+            "Triple\\\\\\backslash",
+            "Four\\\\\\\\backslashes",
+            "Five\\\\\\\\\\backslashes",
+            "Many\\\\\\\\\\\\backslashes",
+
+            # Backslashes in paths (common use case)
+            "Path: C:\\Users\\Documents\\file.txt",
+            "Unix path: /home/user\\file.txt",
+            "Network path: \\\\server\\share\\file.txt",
+            "Relative path: ..\\..\\parent\\file.txt",
+            "Deep path: C:\\Users\\Documents\\Projects\\2024\\file.txt",
+
+            # Multiple backslashes in different positions
+            "Multiple\\backslashes\\here",
+            "Start\\middle\\end",
+            "\\a\\b\\c\\d\\e",
+            "Text\\with\\many\\separated\\backslashes",
+
+            # Backslashes with escape sequences
+            "Escaped\\nnewline",
+            "Escaped\\ttab",
+            "Escaped\\rreturn",
+            "Mixed\\t\\r\\ncharacters",
+            "All\\n\\t\\r\\v\\f",
+            "test single quote: \\'",
+
+            # Consecutive backslashes in escape sequences
+            "Double\\\\nnewline",
+            "Triple\\\\\\nnewline",
+            "Mixed\\\\t\\n\\r",
+
+            # Edge cases
+            "Only\\\\backslashes",
+            "\\",
+            "\\\\",
+            "\\\\\\",
+            "\\\\\\\\",
+            "\\\\\\\\\\",
+
+            # Backslashes with other special characters
+            "Backslash\\and%percent",
+            "Backslash\\and\"quote",
+            "Backslash\\and'apostrophe",
+            "Backslash\\and\\backslash",
+
+            # Long strings with many backslashes
+            "\\".join(["part1", "part2", "part3", "part4", "part5"]),
+            "C:\\" + "\\".join([f"folder{i}" for i in range(10)]),
+
+            # Real-world scenarios
+            "Windows path: C:\\Program Files\\MyApp\\config\\settings.ini",
+            "Regex pattern: \\d+\\s+\\w+",
+            "JSON string: {\"path\": \"C:\\\\Users\\\\file.txt\"}",
+            "Command: cd C:\\Users\\Documents && dir",
+        ]
+
+        print(f"\n🔍 Testing backslash in documents parameter")
+        for i, doc_with_backslash in enumerate(test_cases):
+            test_id = f"test_backslash_{i}_{int(time.time() * 1000)}"
+            print(f"  Testing: {repr(doc_with_backslash)}")
+
+            try:
+                # Attempt to add document with backslash
+                collection.add(
+                    ids=test_id,
+                    embeddings=[1.0, 2.0, 3.0],
+                    documents=doc_with_backslash,
+                    metadatas={"test": "backslash"},
+                )
+
+                # Verify insertion succeeded
+                results = collection.get(ids=test_id)
+                assert len(results["ids"]) == 1, f"Failed to insert document with backslash: {doc_with_backslash}"
+                assert results["documents"][0] == doc_with_backslash, f"Document content mismatch: expected {repr(doc_with_backslash)}, got {repr(results['documents'][0])}"
+                print(f"    ✅ Successfully inserted and verified: {repr(doc_with_backslash)}")
+            except Exception as e:
+                print(f"    ❌ FAILED to insert document with backslash: {repr(doc_with_backslash)}")
+                print(f"       Error: {e}")
+                raise
+
+    def test_percent_in_id(self, db_client):
+        """
+        Bug reproduction: If there's '%' in the id parameter, it failed.
+        """
+        # Create test collection
+        collection_name = f"test_percent_id_{int(time.time() * 1000)}"
+        dimension = 3
+
+        # Create collection using proper API
+        config = HNSWConfiguration(dimension=dimension, distance="cosine")
+        collection = db_client.create_collection(
+            name=collection_name, configuration=config, embedding_function=None
+        )
+
+        # Test cases with percent signs in IDs
+        test_cases = [
+            "id_with_%_percent",
+            "100%_complete",
+            "%percent_at_start",
+            "percent_at_end%",
+            "multiple%percent%signs",
+            "50%_off_sale",
+            "%",
+            "%%",
+            "%%%",
+        ]
+
+        print(f"\n🔍 Testing percent sign in id parameter")
+        for i, id_with_percent in enumerate(test_cases):
+            print(f"  Testing ID: {repr(id_with_percent)}")
+
+            try:
+                # Attempt to add with ID containing percent
+                collection.add(
+                    ids=id_with_percent,
+                    embeddings=[1.0, 2.0, 3.0],
+                    documents="Test document",
+                    metadatas={"test": "percent"},
+                )
+
+                # Verify insertion succeeded
+                results = collection.get(ids=id_with_percent)
+                assert len(results["ids"]) == 1, f"Failed to insert with ID containing percent: {id_with_percent}"
+                assert results["ids"][0] == id_with_percent, f"ID mismatch: expected {repr(id_with_percent)}, got {repr(results['ids'][0])}"
+                print(f"    ✅ Successfully inserted and verified ID: {repr(id_with_percent)}")
+            except ValueError as e:
+                # This is the expected bug - ValueError about unsupported format character
+                error_msg = str(e)
+                if "unsupported format character" in error_msg or "%" in error_msg:
+                    print(f"    ❌ BUG REPRODUCED: Failed to insert with ID containing percent: {repr(id_with_percent)}")
+                    print(f"       Error type: {type(e).__name__}")
+                    print(f"       Error message: {error_msg}")
+                    print(f"       This confirms the bug - percent signs in IDs cause formatting errors")
+                    raise
+                else:
+                    # Different ValueError, re-raise
+                    raise
+            except Exception as e:
+                print(f"    ❌ FAILED to insert with ID containing percent: {repr(id_with_percent)}")
+                print(f"       Error type: {type(e).__name__}")
+                print(f"       Error message: {e}")
+                raise
+
+    def test_double_quote_in_metadata(self, db_client):
+        """
+        Bug reproduction: If there's '"' character in the metadata parameter,
+        it failed to insert data into database.
+        """
+        # Create test collection
+        collection_name = f"test_quote_meta_{int(time.time() * 1000)}"
+        dimension = 3
+
+        # Create collection using proper API
+        config = HNSWConfiguration(dimension=dimension, distance="cosine")
+        collection = db_client.create_collection(
+            name=collection_name, configuration=config, embedding_function=None
+        )
+
+        # Test cases with double quotes in metadata
+        test_cases = [
+            {"title": 'Book "The Great Gatsby"'},
+            {"description": 'He said "Hello World"'},
+            {"quote": '"To be or not to be"'},
+            {"text": 'Multiple "quotes" in "one" string'},
+            {"value": '"'},
+            {"nested": {"inner": '"quoted"'}},
+            {"mixed": 'Start "middle" end'},
+            {"json_like": '{"key": "value"}'},
+        ]
+
+        print(f"\n🔍 Testing double quote in metadata parameter")
+        for i, metadata_with_quote in enumerate(test_cases):
+            test_id = f"test_quote_{i}_{int(time.time() * 1000)}"
+            print(f"  Testing metadata: {repr(metadata_with_quote)}")
+
+            try:
+                # Attempt to add with metadata containing double quotes
+                collection.add(
+                    ids=test_id,
+                    embeddings=[1.0, 2.0, 3.0],
+                    documents="Test document",
+                    metadatas=metadata_with_quote,
+                )
+
+                # Verify insertion succeeded
+                results = collection.get(ids=test_id)
+                assert len(results["ids"]) == 1, f"Failed to insert with metadata containing double quote: {metadata_with_quote}"
+                assert results["metadatas"][0] == metadata_with_quote, f"Metadata mismatch: expected {repr(metadata_with_quote)}, got {repr(results['metadatas'][0])}"
+                print(f"    ✅ Successfully inserted and verified metadata: {repr(metadata_with_quote)}")
+            except Exception as e:
+                print(f"    ❌ FAILED to insert with metadata containing double quote: {repr(metadata_with_quote)}")
+                print(f"       Error: {e}")
+                raise
+
+    def test_all_special_characters_combined(self, db_client):
+        """
+        Combined test: Test all three special characters together
+        """
+        # Create test collection
+        collection_name = f"test_all_special_{int(time.time() * 1000)}"
+        dimension = 3
+
+        # Create collection using proper API
+        config = HNSWConfiguration(dimension=dimension, distance="cosine")
+        collection = db_client.create_collection(
+            name=collection_name, configuration=config, embedding_function=None
+        )
+
+        print(f"\n🔍 Testing all special characters combined")
+        test_id = "id_with_%_percent"
+        test_document = "Path: C:\\Users\\Documents\\file.txt"
+        test_metadata = {"title": 'Book "The Great Gatsby"', "path": "C:\\Users\\Documents"}
+
+        try:
+            collection.add(
+                ids=test_id,
+                embeddings=[1.0, 2.0, 3.0],
+                documents=test_document,
+                metadatas=test_metadata,
+            )
+
+            # Verify insertion succeeded
+            results = collection.get(ids=test_id)
+            assert len(results["ids"]) == 1, "Failed to insert with all special characters"
+            assert results["ids"][0] == test_id, f"ID mismatch"
+            assert results["documents"][0] == test_document, f"Document mismatch"
+            assert results["metadatas"][0] == test_metadata, f"Metadata mismatch"
+            print(f"    ✅ Successfully inserted and verified all special characters combined")
+        except Exception as e:
+            print(f"    ❌ FAILED to insert with all special characters combined")
+            print(f"       Error: {e}")
+            raise
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/integration_tests/test_special_characters_bugs.py
+++ b/tests/integration_tests/test_special_characters_bugs.py
@@ -39,27 +39,23 @@ class TestSpecialCharactersBugs:
             "Single\\backslash",
             "\\Backslash at start",
             "Backslash at end\\",
-
             # Multiple consecutive backslashes
             "Double\\\\backslash",
             "Triple\\\\\\backslash",
             "Four\\\\\\\\backslashes",
             "Five\\\\\\\\\\backslashes",
             "Many\\\\\\\\\\\\backslashes",
-
             # Backslashes in paths (common use case)
             "Path: C:\\Users\\Documents\\file.txt",
             "Unix path: /home/user\\file.txt",
             "Network path: \\\\server\\share\\file.txt",
             "Relative path: ..\\..\\parent\\file.txt",
             "Deep path: C:\\Users\\Documents\\Projects\\2024\\file.txt",
-
             # Multiple backslashes in different positions
             "Multiple\\backslashes\\here",
             "Start\\middle\\end",
             "\\a\\b\\c\\d\\e",
             "Text\\with\\many\\separated\\backslashes",
-
             # Backslashes with escape sequences
             "Escaped\\nnewline",
             "Escaped\\ttab",
@@ -67,12 +63,10 @@ class TestSpecialCharactersBugs:
             "Mixed\\t\\r\\ncharacters",
             "All\\n\\t\\r\\v\\f",
             "test single quote: \\'",
-
             # Consecutive backslashes in escape sequences
             "Double\\\\nnewline",
             "Triple\\\\\\nnewline",
             "Mixed\\\\t\\n\\r",
-
             # Edge cases
             "Only\\\\backslashes",
             "\\",
@@ -80,21 +74,18 @@ class TestSpecialCharactersBugs:
             "\\\\\\",
             "\\\\\\\\",
             "\\\\\\\\\\",
-
             # Backslashes with other special characters
             "Backslash\\and%percent",
-            "Backslash\\and\"quote",
+            'Backslash\\and"quote',
             "Backslash\\and'apostrophe",
             "Backslash\\and\\backslash",
-
             # Long strings with many backslashes
             "\\".join(["part1", "part2", "part3", "part4", "part5"]),
             "C:\\" + "\\".join([f"folder{i}" for i in range(10)]),
-
             # Real-world scenarios
             "Windows path: C:\\Program Files\\MyApp\\config\\settings.ini",
             "Regex pattern: \\d+\\s+\\w+",
-            "JSON string: {\"path\": \"C:\\\\Users\\\\file.txt\"}",
+            'JSON string: {"path": "C:\\\\Users\\\\file.txt"}',
             "Command: cd C:\\Users\\Documents && dir",
         ]
 
@@ -114,11 +105,19 @@ class TestSpecialCharactersBugs:
 
                 # Verify insertion succeeded
                 results = collection.get(ids=test_id)
-                assert len(results["ids"]) == 1, f"Failed to insert document with backslash: {doc_with_backslash}"
-                assert results["documents"][0] == doc_with_backslash, f"Document content mismatch: expected {repr(doc_with_backslash)}, got {repr(results['documents'][0])}"
-                print(f"    ✅ Successfully inserted and verified: {repr(doc_with_backslash)}")
+                assert len(results["ids"]) == 1, (
+                    f"Failed to insert document with backslash: {doc_with_backslash}"
+                )
+                assert results["documents"][0] == doc_with_backslash, (
+                    f"Document content mismatch: expected {repr(doc_with_backslash)}, got {repr(results['documents'][0])}"
+                )
+                print(
+                    f"    ✅ Successfully inserted and verified: {repr(doc_with_backslash)}"
+                )
             except Exception as e:
-                print(f"    ❌ FAILED to insert document with backslash: {repr(doc_with_backslash)}")
+                print(
+                    f"    ❌ FAILED to insert document with backslash: {repr(doc_with_backslash)}"
+                )
                 print(f"       Error: {e}")
                 raise
 
@@ -164,23 +163,35 @@ class TestSpecialCharactersBugs:
 
                 # Verify insertion succeeded
                 results = collection.get(ids=id_with_percent)
-                assert len(results["ids"]) == 1, f"Failed to insert with ID containing percent: {id_with_percent}"
-                assert results["ids"][0] == id_with_percent, f"ID mismatch: expected {repr(id_with_percent)}, got {repr(results['ids'][0])}"
-                print(f"    ✅ Successfully inserted and verified ID: {repr(id_with_percent)}")
+                assert len(results["ids"]) == 1, (
+                    f"Failed to insert with ID containing percent: {id_with_percent}"
+                )
+                assert results["ids"][0] == id_with_percent, (
+                    f"ID mismatch: expected {repr(id_with_percent)}, got {repr(results['ids'][0])}"
+                )
+                print(
+                    f"    ✅ Successfully inserted and verified ID: {repr(id_with_percent)}"
+                )
             except ValueError as e:
                 # This is the expected bug - ValueError about unsupported format character
                 error_msg = str(e)
                 if "unsupported format character" in error_msg or "%" in error_msg:
-                    print(f"    ❌ BUG REPRODUCED: Failed to insert with ID containing percent: {repr(id_with_percent)}")
+                    print(
+                        f"    ❌ BUG REPRODUCED: Failed to insert with ID containing percent: {repr(id_with_percent)}"
+                    )
                     print(f"       Error type: {type(e).__name__}")
                     print(f"       Error message: {error_msg}")
-                    print(f"       This confirms the bug - percent signs in IDs cause formatting errors")
+                    print(
+                        f"       This confirms the bug - percent signs in IDs cause formatting errors"
+                    )
                     raise
                 else:
                     # Different ValueError, re-raise
                     raise
             except Exception as e:
-                print(f"    ❌ FAILED to insert with ID containing percent: {repr(id_with_percent)}")
+                print(
+                    f"    ❌ FAILED to insert with ID containing percent: {repr(id_with_percent)}"
+                )
                 print(f"       Error type: {type(e).__name__}")
                 print(f"       Error message: {e}")
                 raise
@@ -228,11 +239,19 @@ class TestSpecialCharactersBugs:
 
                 # Verify insertion succeeded
                 results = collection.get(ids=test_id)
-                assert len(results["ids"]) == 1, f"Failed to insert with metadata containing double quote: {metadata_with_quote}"
-                assert results["metadatas"][0] == metadata_with_quote, f"Metadata mismatch: expected {repr(metadata_with_quote)}, got {repr(results['metadatas'][0])}"
-                print(f"    ✅ Successfully inserted and verified metadata: {repr(metadata_with_quote)}")
+                assert len(results["ids"]) == 1, (
+                    f"Failed to insert with metadata containing double quote: {metadata_with_quote}"
+                )
+                assert results["metadatas"][0] == metadata_with_quote, (
+                    f"Metadata mismatch: expected {repr(metadata_with_quote)}, got {repr(results['metadatas'][0])}"
+                )
+                print(
+                    f"    ✅ Successfully inserted and verified metadata: {repr(metadata_with_quote)}"
+                )
             except Exception as e:
-                print(f"    ❌ FAILED to insert with metadata containing double quote: {repr(metadata_with_quote)}")
+                print(
+                    f"    ❌ FAILED to insert with metadata containing double quote: {repr(metadata_with_quote)}"
+                )
                 print(f"       Error: {e}")
                 raise
 
@@ -253,7 +272,10 @@ class TestSpecialCharactersBugs:
         print(f"\n🔍 Testing all special characters combined")
         test_id = "id_with_%_percent"
         test_document = "Path: C:\\Users\\Documents\\file.txt"
-        test_metadata = {"title": 'Book "The Great Gatsby"', "path": "C:\\Users\\Documents"}
+        test_metadata = {
+            "title": 'Book "The Great Gatsby"',
+            "path": "C:\\Users\\Documents",
+        }
 
         try:
             collection.add(
@@ -265,11 +287,15 @@ class TestSpecialCharactersBugs:
 
             # Verify insertion succeeded
             results = collection.get(ids=test_id)
-            assert len(results["ids"]) == 1, "Failed to insert with all special characters"
+            assert len(results["ids"]) == 1, (
+                "Failed to insert with all special characters"
+            )
             assert results["ids"][0] == test_id, f"ID mismatch"
             assert results["documents"][0] == test_document, f"Document mismatch"
             assert results["metadatas"][0] == test_metadata, f"Metadata mismatch"
-            print(f"    ✅ Successfully inserted and verified all special characters combined")
+            print(
+                f"    ✅ Successfully inserted and verified all special characters combined"
+            )
         except Exception as e:
             print(f"    ❌ FAILED to insert with all special characters combined")
             print(f"       Error: {e}")

--- a/tests/unit_tests/test_default_embedding_function.py
+++ b/tests/unit_tests/test_default_embedding_function.py
@@ -1,6 +1,7 @@
 """
 Unit tests for DefaultEmbeddingFunction.
 """
+
 import pytest
 from typing import Dict, Any
 
@@ -55,6 +56,7 @@ class TestDefaultEmbeddingFunctionPersistence:
 
         assert isinstance(restored_ef, DefaultEmbeddingFunction)
         assert restored_ef.model_name == original_ef.model_name
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/unit_tests/test_env_guard.py
+++ b/tests/unit_tests/test_env_guard.py
@@ -3,6 +3,7 @@ Example tests demonstrating how to use EnvGuard for environment variable managem
 
 This file shows various usage patterns for the EnvGuard class.
 """
+
 import os
 import pytest
 
@@ -101,15 +102,14 @@ class TestEnvGuard:
         original_custom = os.environ.get("CUSTOM_OPENAI_KEY")
 
         # Simulate a test that needs a custom API key
-        with EnvGuard(
-            CUSTOM_OPENAI_KEY=original_key or "test-key"
-        ):
+        with EnvGuard(CUSTOM_OPENAI_KEY=original_key or "test-key"):
             # Test code that uses CUSTOM_OPENAI_KEY
             assert os.environ.get("CUSTOM_OPENAI_KEY") is not None
 
         # Original values restored
         assert os.environ.get("OPENAI_API_KEY") == original_key
         assert os.environ.get("CUSTOM_OPENAI_KEY") == original_custom
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/unit_tests/test_openai_embedding_function.py
+++ b/tests/unit_tests/test_openai_embedding_function.py
@@ -18,6 +18,7 @@ from pyseekdb.client.embedding_function import dimension_of
 from .test_utils import env_guard
 import importlib.util
 
+
 def is_openai_available() -> bool:
     """
     Check if openai is available for testing.
@@ -27,10 +28,11 @@ def is_openai_available() -> bool:
     """
     return importlib.util.find_spec("openai") is not None
 
+
 # Skip this test by default - it requires external API access and API keys
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY") or not is_openai_available(),
-    reason="OPENAI_API_KEY environment variable must be set"
+    reason="OPENAI_API_KEY environment variable must be set",
 )
 class TestOpenAIEmbeddingFunction:
     """Test OpenAIEmbeddingFunction - skipped by default, requires manual execution"""
@@ -382,9 +384,9 @@ class TestOpenAIEmbeddingFunction:
             )
             print(f"   {model_name}: {ef.dimension} dimensions")
 
+
 @pytest.mark.skipif(
-    not is_openai_available(),
-    reason="openai is not available on this system"
+    not is_openai_available(), reason="openai is not available on this system"
 )
 class TestOpenAIEmbeddingFunctionPersistence:
     """Test persistence for OpenAIEmbeddingFunction"""
@@ -417,7 +419,7 @@ class TestOpenAIEmbeddingFunctionPersistence:
                 api_base="https://custom-api.openai.com/v1",
                 dimensions=512,
                 timeout=60,
-                max_retries=5
+                max_retries=5,
             )
             config = ef.get_config()
 
@@ -432,8 +434,7 @@ class TestOpenAIEmbeddingFunctionPersistence:
         """Test that get_config() correctly includes dimensions parameter"""
         with env_guard(OPENAI_API_KEY="test-key"):
             ef = OpenAIEmbeddingFunction(
-                model_name="text-embedding-3-small",
-                dimensions=256
+                model_name="text-embedding-3-small", dimensions=256
             )
             config = ef.get_config()
 
@@ -446,7 +447,7 @@ class TestOpenAIEmbeddingFunctionPersistence:
             "api_key_env": "OPENAI_API_KEY",
             "api_base": "https://api.openai.com/v1",
             "dimensions": None,
-            "client_kwargs": {}
+            "client_kwargs": {},
         }
 
         with env_guard(OPENAI_API_KEY="test-key"):
@@ -465,7 +466,7 @@ class TestOpenAIEmbeddingFunctionPersistence:
             "api_key_env": "CUSTOM_OPENAI_KEY",
             "api_base": "https://custom-api.openai.com/v1",
             "dimensions": 512,
-            "client_kwargs": {"timeout": 60, "max_retries": 5}
+            "client_kwargs": {"timeout": 60, "max_retries": 5},
         }
 
         with env_guard(CUSTOM_OPENAI_KEY="test-key"):
@@ -483,8 +484,7 @@ class TestOpenAIEmbeddingFunctionPersistence:
         """Test complete roundtrip: get_config -> build_from_config"""
         with env_guard(OPENAI_API_KEY="test-key"):
             original_ef = OpenAIEmbeddingFunction(
-                model_name="text-embedding-3-small",
-                dimensions=256
+                model_name="text-embedding-3-small", dimensions=256
             )
 
             config = original_ef.get_config()
@@ -495,6 +495,7 @@ class TestOpenAIEmbeddingFunctionPersistence:
             assert restored_ef.api_key_env == original_ef.api_key_env
             assert restored_ef.api_base == original_ef.api_base
             assert restored_ef._dimensions_param == original_ef._dimensions_param
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/unit_tests/test_qwen_embedding_function.py
+++ b/tests/unit_tests/test_qwen_embedding_function.py
@@ -18,6 +18,7 @@ from pyseekdb.client.embedding_function import dimension_of
 from .test_utils import env_guard
 import importlib.util
 
+
 def is_openai_available() -> bool:
     """
     Check if openai is available for testing.
@@ -27,10 +28,11 @@ def is_openai_available() -> bool:
     """
     return importlib.util.find_spec("openai") is not None
 
+
 # Skip this test by default - it requires external API access and API keys
 @pytest.mark.skipif(
     not os.environ.get("DASHSCOPE_API_KEY") or not is_openai_available(),
-    reason="DASHSCOPE_API_KEY environment variable must be set"
+    reason="DASHSCOPE_API_KEY environment variable must be set",
 )
 class TestQwenEmbeddingFunction:
     """Test QwenEmbeddingFunction - skipped by default, requires manual execution"""
@@ -349,9 +351,9 @@ class TestQwenEmbeddingFunction:
         assert dimensions["text-embedding-v4"] == 1024
         print(f"   Model dimensions: {dimensions}")
 
+
 @pytest.mark.skipif(
-    not is_openai_available(),
-    reason="openai is not available on this system"
+    not is_openai_available(), reason="openai is not available on this system"
 )
 class TestQwenEmbeddingFunctionPersistence:
     """Test persistence for QwenEmbeddingFunction"""
@@ -369,7 +371,10 @@ class TestQwenEmbeddingFunctionPersistence:
             assert isinstance(config, dict)
             assert config["model_name"] == "text-embedding-v1"
             assert config["api_key_env"] == "DASHSCOPE_API_KEY"
-            assert config["api_base"] == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            assert (
+                config["api_base"]
+                == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            )
             assert config["dimensions"] is None
             assert isinstance(config["client_kwargs"], dict)
             # name should NOT be in config
@@ -383,7 +388,7 @@ class TestQwenEmbeddingFunctionPersistence:
                 api_key_env="CUSTOM_QWEN_KEY",
                 api_base="https://custom-dashscope.com/v1",
                 dimensions=512,
-                timeout=60
+                timeout=60,
             )
             config = ef.get_config()
 
@@ -396,10 +401,7 @@ class TestQwenEmbeddingFunctionPersistence:
     def test_get_config_with_dimensions(self):
         """Test that get_config() correctly includes dimensions parameter"""
         with env_guard(DASHSCOPE_API_KEY="test-key"):
-            ef = QwenEmbeddingFunction(
-                model_name="text-embedding-v3",
-                dimensions=256
-            )
+            ef = QwenEmbeddingFunction(model_name="text-embedding-v3", dimensions=256)
             config = ef.get_config()
 
             assert config["dimensions"] == 256
@@ -411,7 +413,7 @@ class TestQwenEmbeddingFunctionPersistence:
             "api_key_env": "DASHSCOPE_API_KEY",
             "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
             "dimensions": None,
-            "client_kwargs": {}
+            "client_kwargs": {},
         }
 
         with env_guard(DASHSCOPE_API_KEY="test-key"):
@@ -420,7 +422,10 @@ class TestQwenEmbeddingFunctionPersistence:
             assert isinstance(restored_ef, QwenEmbeddingFunction)
             assert restored_ef.model_name == "text-embedding-v1"
             assert restored_ef.api_key_env == "DASHSCOPE_API_KEY"
-            assert restored_ef.api_base == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            assert (
+                restored_ef.api_base
+                == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            )
             assert restored_ef._dimensions_param is None
 
     def test_build_from_config_with_custom_values(self):
@@ -430,7 +435,7 @@ class TestQwenEmbeddingFunctionPersistence:
             "api_key_env": "CUSTOM_QWEN_KEY",
             "api_base": "https://custom-dashscope.com/v1",
             "dimensions": 512,
-            "client_kwargs": {"timeout": 60}
+            "client_kwargs": {"timeout": 60},
         }
 
         with env_guard(CUSTOM_QWEN_KEY="test-key"):
@@ -447,8 +452,7 @@ class TestQwenEmbeddingFunctionPersistence:
         """Test complete roundtrip: get_config -> build_from_config"""
         with env_guard(DASHSCOPE_API_KEY="test-key"):
             original_ef = QwenEmbeddingFunction(
-                model_name="text-embedding-v1",
-                dimensions=256
+                model_name="text-embedding-v1", dimensions=256
             )
 
             config = original_ef.get_config()

--- a/tests/unit_tests/test_sentence_transformer_embedding_function.py
+++ b/tests/unit_tests/test_sentence_transformer_embedding_function.py
@@ -8,6 +8,7 @@ and restored from them correctly.
 To run this test:
     pytest tests/unit_tests/test_sentence_transformer_embedding_function_persistence.py -v
 """
+
 import pytest
 from typing import Dict, Any
 import importlib.util
@@ -16,6 +17,7 @@ from pyseekdb.utils.embedding_functions import SentenceTransformerEmbeddingFunct
 
 # # This will work on both CPU and CUDA systems
 # pip install sentence-transformers torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+
 
 def is_cuda_available() -> bool:
     """
@@ -26,9 +28,11 @@ def is_cuda_available() -> bool:
     """
     try:
         import torch
+
         return torch.cuda.is_available()
     except ImportError:
         return False
+
 
 def is_sentence_transformers_available() -> bool:
     """
@@ -39,9 +43,10 @@ def is_sentence_transformers_available() -> bool:
     """
     return importlib.util.find_spec("sentence_transformers") is not None
 
+
 @pytest.mark.skipif(
     not is_sentence_transformers_available(),
-    reason="sentence-transformers is not available on this system"
+    reason="sentence-transformers is not available on this system",
 )
 class TestSentenceTransformerEmbeddingFunctionPersistence:
     """Test persistence for SentenceTransformerEmbeddingFunction"""
@@ -65,8 +70,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
         assert "name" not in config
 
     @pytest.mark.skipif(
-        not is_cuda_available(),
-        reason="CUDA is not available on this system"
+        not is_cuda_available(), reason="CUDA is not available on this system"
     )
     def test_get_config_with_custom_values(self):
         """Test that get_config() returns correct config with custom values"""
@@ -74,7 +78,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
             model_name="all-mpnet-base-v2",
             device="cuda",
             normalize_embeddings=True,
-            trust_remote_code=True
+            trust_remote_code=True,
         )
         config = ef.get_config()
 
@@ -90,7 +94,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
             device="cpu",
             normalize_embeddings=False,
             trust_remote_code=True,
-            use_auth_token="test-token"
+            use_auth_token="test-token",
         )
         config = ef.get_config()
 
@@ -103,7 +107,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
             "model_name": "all-MiniLM-L6-v2",
             "device": "cpu",
             "normalize_embeddings": False,
-            "kwargs": {}
+            "kwargs": {},
         }
 
         restored_ef = SentenceTransformerEmbeddingFunction.build_from_config(config)
@@ -115,8 +119,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
         assert restored_ef.kwargs == {}
 
     @pytest.mark.skipif(
-        not is_cuda_available(),
-        reason="CUDA is not available on this system"
+        not is_cuda_available(), reason="CUDA is not available on this system"
     )
     def test_build_from_config_with_custom_values(self):
         """Test that build_from_config() restores instance with custom values"""
@@ -124,7 +127,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
             "model_name": "all-mpnet-base-v2",
             "device": "cuda",
             "normalize_embeddings": True,
-            "kwargs": {"trust_remote_code": True}
+            "kwargs": {"trust_remote_code": True},
         }
 
         restored_ef = SentenceTransformerEmbeddingFunction.build_from_config(config)
@@ -138,9 +141,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
     def test_build_from_config_with_missing_fields_uses_defaults(self):
         """Test that build_from_config() uses defaults for missing fields"""
         # Test with minimal config
-        config = {
-            "model_name": "all-MiniLM-L6-v2"
-        }
+        config = {"model_name": "all-MiniLM-L6-v2"}
 
         restored_ef = SentenceTransformerEmbeddingFunction.build_from_config(config)
 
@@ -153,10 +154,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
 
     def test_build_from_config_with_partial_config(self):
         """Test that build_from_config() handles partial configuration"""
-        config = {
-            "model_name": "all-mpnet-base-v2",
-            "normalize_embeddings": True
-        }
+        config = {"model_name": "all-mpnet-base-v2", "normalize_embeddings": True}
 
         restored_ef = SentenceTransformerEmbeddingFunction.build_from_config(config)
 
@@ -172,7 +170,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
             model_name="all-mpnet-base-v2",
             device="cpu",
             normalize_embeddings=True,
-            trust_remote_code=True
+            trust_remote_code=True,
         )
 
         config = original_ef.get_config()
@@ -185,28 +183,24 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
         assert restored_ef.kwargs == original_ef.kwargs
 
     @pytest.mark.skipif(
-        not is_cuda_available(),
-        reason="CUDA is not available on this system"
+        not is_cuda_available(), reason="CUDA is not available on this system"
     )
     def test_initialization_with_cuda(self):
         """Test that SentenceTransformerEmbeddingFunction can be initialized with CUDA device"""
         ef = SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2",
-            device="cuda"
+            model_name="all-MiniLM-L6-v2", device="cuda"
         )
 
         assert ef.device == "cuda"
         assert ef.model_name == "all-MiniLM-L6-v2"
 
     @pytest.mark.skipif(
-        not is_cuda_available(),
-        reason="CUDA is not available on this system"
+        not is_cuda_available(), reason="CUDA is not available on this system"
     )
     def test_embeddings_with_cuda(self):
         """Test that embeddings can be generated using CUDA"""
         ef = SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2",
-            device="cuda"
+            model_name="all-MiniLM-L6-v2", device="cuda"
         )
 
         # Generate embeddings
@@ -218,15 +212,12 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
         assert len(embeddings[0]) == len(embeddings[1])  # Same dimension
 
     @pytest.mark.skipif(
-        not is_cuda_available(),
-        reason="CUDA is not available on this system"
+        not is_cuda_available(), reason="CUDA is not available on this system"
     )
     def test_get_config_with_cuda(self):
         """Test that get_config() correctly saves CUDA device setting"""
         ef = SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2",
-            device="cuda",
-            normalize_embeddings=True
+            model_name="all-MiniLM-L6-v2", device="cuda", normalize_embeddings=True
         )
 
         config = ef.get_config()
@@ -236,8 +227,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
         assert config["normalize_embeddings"] is True
 
     @pytest.mark.skipif(
-        not is_cuda_available(),
-        reason="CUDA is not available on this system"
+        not is_cuda_available(), reason="CUDA is not available on this system"
     )
     def test_build_from_config_with_cuda(self):
         """Test that build_from_config() correctly restores CUDA device setting"""
@@ -245,7 +235,7 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
             "model_name": "all-MiniLM-L6-v2",
             "device": "cuda",
             "normalize_embeddings": False,
-            "kwargs": {}
+            "kwargs": {},
         }
 
         restored_ef = SentenceTransformerEmbeddingFunction.build_from_config(config)
@@ -255,15 +245,12 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
         assert restored_ef.model_name == "all-MiniLM-L6-v2"
 
     @pytest.mark.skipif(
-        not is_cuda_available(),
-        reason="CUDA is not available on this system"
+        not is_cuda_available(), reason="CUDA is not available on this system"
     )
     def test_persistence_roundtrip_with_cuda(self):
         """Test complete roundtrip with CUDA: get_config -> build_from_config"""
         original_ef = SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2",
-            device="cuda",
-            normalize_embeddings=True
+            model_name="all-MiniLM-L6-v2", device="cuda", normalize_embeddings=True
         )
 
         config = original_ef.get_config()
@@ -275,18 +262,15 @@ class TestSentenceTransformerEmbeddingFunctionPersistence:
         assert restored_ef.normalize_embeddings == original_ef.normalize_embeddings
 
     @pytest.mark.skipif(
-        not is_cuda_available(),
-        reason="CUDA is not available on this system"
+        not is_cuda_available(), reason="CUDA is not available on this system"
     )
     def test_cuda_vs_cpu_config_consistency(self):
         """Test that CUDA and CPU configs are handled consistently"""
         ef_cuda = SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2",
-            device="cuda"
+            model_name="all-MiniLM-L6-v2", device="cuda"
         )
         ef_cpu = SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2",
-            device="cpu"
+            model_name="all-MiniLM-L6-v2", device="cpu"
         )
 
         config_cuda = ef_cuda.get_config()

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -3,6 +3,7 @@ Test utilities for pyseekdb unit tests.
 
 Provides helper classes and functions for testing, including environment variable management.
 """
+
 import os
 from contextlib import contextmanager
 from typing import Dict, Optional

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <4.0"
+requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version < '3.12'",


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
close #116 
If there's '%' in the `id` field, the `collection.get` would failed to execute.
I use parameterized query with pymysql, so we should treat the `id` parameter as a parameter in `cursor.execute`. But it's serialized in SQL now.

Currently:
```sql
cursor.execute('SELECT ID, DOCUMENT FROM COLLECTION WHERE id in (CAST('id_%_percent' AS BINARY)) LIMIT %s, OFFSET %s', 5, 0)
```

After I fix the bug:
```sql
cursor.execute('SELECT ID, DOCUMENT FROM COLLECTION WHERE id in (CAST(%s AS BINARY)) LIMIT %s, OFFSET %s', ('id_%_percent', 5, 0))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IDs are now handled safely to avoid formatting issues; percent signs and backslashes in IDs/fields are better escaped.
  * Several info logs were toned down to debug to reduce log noise.

* **Tests**
  * Added integration tests covering percent signs, backslashes, quotes, and combined special-character scenarios for insert/get flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->