### PR TITLE
change mock embeddings to generated by default embedding function

### DIFF
--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -13,7 +13,6 @@ This is a complete reference for all client capabilities.
 """
 
 import uuid
-import random
 import pyseekdb
 
 # ============================================================================
@@ -22,7 +21,7 @@ import pyseekdb
 
 # Option 1: Embedded mode (local seekdb)
 client = pyseekdb.Client(
-    # path="./seekdb",
+    # path="./seekdb.db",
     # database="test"
 )
 
@@ -50,28 +49,35 @@ client = pyseekdb.Client(
 # ============================================================================
 
 collection_name = "comprehensive_example"
-dimension = 128
+dimension = 384
 
 # 2.1 Create a collection
 from pyseekdb import HNSWConfiguration
 
+# create a collection with default configuration and default embedding function
+collection = client.get_or_create_collection(
+    name=collection_name,
+)
+
+# 2.2 Create a collection with custom configuration and no embedding function
 config = HNSWConfiguration(dimension=dimension, distance="cosine")
+default_ef = pyseekdb.DefaultEmbeddingFunction()
 collection = client.get_or_create_collection(
     name=collection_name,
     configuration=config,
-    embedding_function=None,  # Explicitly set to None since we're using custom 128-dim embeddings
+    embedding_function=None,  # Explicitly set to None since we're using custom 384-dim embeddings
 )
 
-# 2.2 Check if collection exists
+# 2.3 Check if collection exists
 exists = client.has_collection(collection_name)
 
-# 2.3 Get collection object
+# 2.4 Get collection object
 retrieved_collection = client.get_collection(collection_name, embedding_function=None)
 
-# 2.4 List all collections
+# 2.5 List all collections
 all_collections = client.list_collections()
 
-# 2.5 Get or create collection (creates if doesn't exist)
+# 2.6 Get or create collection (creates if doesn't exist)
 config2 = HNSWConfiguration(dimension=64, distance="cosine")
 collection2 = client.get_or_create_collection(
     name="another_collection",
@@ -79,12 +85,41 @@ collection2 = client.get_or_create_collection(
     embedding_function=None,  # Explicitly set to None since we're using custom 64-dim embeddings
 )
 
+
+# 2.7 Create a collection with custom embedding function
+@pyseekdb.register_embedding_function
+class CustomEmbeddingFunction(pyseekdb.EmbeddingFunction):
+    def __init__(self):
+        self._ef = (
+            pyseekdb.DefaultEmbeddingFunction()
+        )  # use the default embedding function
+
+    def __call__(self, input: pyseekdb.Documents) -> pyseekdb.Embeddings:
+        return self._ef(input)
+
+    def get_config(self) -> dict:
+        return self._ef.get_config()
+
+    @staticmethod
+    def build_from_config(config: dict) -> "CustomEmbeddingFunction":
+        return CustomEmbeddingFunction(config=config)
+
+    @staticmethod
+    def name() -> str:
+        return "custom_embedding"
+
+
+custom_ef = CustomEmbeddingFunction()
+collection3 = client.create_collection(
+    name="custom_embedding_collection",
+    embedding_function=custom_ef,
+)
+
 # ============================================================================
 # PART 3: DML OPERATIONS - ADD DATA
 # ============================================================================
 
 # Generate sample data
-random.seed(42)
 documents = [
     "Machine learning is transforming the way we solve problems",
     "Python programming language is widely used in data science",
@@ -98,18 +133,19 @@ documents = [
 
 # Generate embeddings (in real usage, use an embedding model)
 embeddings = []
-for i in range(len(documents)):
-    vector = [random.random() for _ in range(dimension)]
+for document in documents:
+    vector = default_ef(document)
     embeddings.append(vector)
 
 ids = [str(uuid.uuid4()) for _ in documents]
 
 # 3.1 Add single item
 single_id = str(uuid.uuid4())
+document = "This is a single document"
 collection.add(
     ids=single_id,
     documents="This is a single document",
-    embeddings=[random.random() for _ in range(dimension)],
+    embeddings=default_ef(document),
     metadatas={"type": "single", "category": "test"},
 )
 
@@ -158,7 +194,7 @@ collection.update(
 collection.update(
     ids=ids[1:3],
     documents=["Updated document 1", "Updated document 2"],
-    embeddings=[[random.random() for _ in range(dimension)] for _ in range(2)],
+    embeddings=embeddings,
     metadatas=[
         {"category": "Programming", "score": 95, "updated": True},
         {"category": "Database", "score": 97, "updated": True},
@@ -166,8 +202,13 @@ collection.update(
 )
 
 # 4.3 Update embeddings
-new_embeddings = [[random.random() for _ in range(dimension)] for _ in range(2)]
-collection.update(ids=ids[2:4], embeddings=new_embeddings)
+update_documents = [
+    "Search engines find relevant documents using semantic vectors",
+    "Deep learning architectures are inspired by biological neurons",
+    "Text analytics empowers machines to interpret and extract meaning from language",
+]
+update_embeddings = [default_ef(document) for document in update_documents]
+collection.update(ids=ids[2:4], embeddings=update_embeddings)
 
 # ============================================================================
 # PART 5: DML OPERATIONS - UPSERT DATA
@@ -177,25 +218,31 @@ collection.update(ids=ids[2:4], embeddings=new_embeddings)
 collection.upsert(
     ids=ids[0],
     documents="Upserted document (was updated)",
-    embeddings=[random.random() for _ in range(dimension)],
+    embeddings=default_ef(document),
     metadatas={"category": "AI", "upserted": True},
 )
 
 # 5.2 Upsert new item (will insert)
 new_id = str(uuid.uuid4())
+new_document = "This is a new document from upsert"
 collection.upsert(
     ids=new_id,
     documents="This is a new document from upsert",
-    embeddings=[random.random() for _ in range(dimension)],
+    embeddings=default_ef(new_document),
     metadatas={"category": "New", "upserted": True},
 )
 
 # 5.3 Upsert multiple items
 upsert_ids = [ids[4], str(uuid.uuid4())]  # One existing, one new
+upsert_documents = [
+    "Upserted document 1",
+    "Upserted document 2",
+]
+upsert_embeddings = [default_ef(document) for document in upsert_documents]
 collection.upsert(
     ids=upsert_ids,
-    documents=["Upserted doc 1", "Upserted doc 2"],
-    embeddings=[[random.random() for _ in range(dimension)] for _ in range(2)],
+    documents=upsert_documents,
+    embeddings=upsert_embeddings,
     metadatas=[{"upserted": True}, {"upserted": True}],
 )
 

--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -226,8 +226,8 @@ new_id = str(uuid.uuid4())
 new_document = "This is a new document from upsert"
 collection.upsert(
     ids=new_id,
-    documents="This is a new document from upsert",
-    embeddings=default_ef("This is a new document from upsert"),
+    documents=new_document,
+    embeddings=default_ef(new_document),
     metadatas={"category": "New", "upserted": True},
 )
 

--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -15,24 +15,23 @@ This is a complete reference for all client capabilities.
 import uuid
 import pyseekdb
 
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
 # ============================================================================
 # PART 1: CLIENT CONNECTION
 # ============================================================================
 
 # Option 1: Embedded mode (local seekdb)
-client = pyseekdb.Client(
-    # path="./seekdb.db",
-    # database="test"
-)
+# client = pyseekdb.Client(
+#     # path="./seekdb.db",
+#     # database="test"
+# )
 
 # Option 2: Server mode (remote seekdb server)
-# client = pyseekdb.Client(
-#     host="127.0.0.1",
-#     port=2881,
-#     database="test",
-#     user="root",
-#     password=""
-# )
+client = pyseekdb.Client(
+    host="6.12.233.133", port=10202, database="test", user="root", password=""
+)
 
 # Option 3: Remote server mode (OceanBase Server)
 # client = pyseekdb.Client(
@@ -56,7 +55,7 @@ from pyseekdb import HNSWConfiguration
 
 # create a collection with default configuration and default embedding function
 collection = client.get_or_create_collection(
-    name=collection_name,
+    name="demo_default_collection",
 )
 
 # 2.2 Create a collection with custom configuration and no embedding function
@@ -74,10 +73,7 @@ exists = client.has_collection(collection_name)
 # 2.4 Get collection object
 retrieved_collection = client.get_collection(collection_name, embedding_function=None)
 
-# 2.5 List all collections
-all_collections = client.list_collections()
-
-# 2.6 Get or create collection (creates if doesn't exist)
+# 2.5 Get or create collection (creates if doesn't exist)
 config2 = HNSWConfiguration(dimension=64, distance="cosine")
 collection2 = client.get_or_create_collection(
     name="another_collection",
@@ -86,7 +82,7 @@ collection2 = client.get_or_create_collection(
 )
 
 
-# 2.7 Create a collection with custom embedding function
+# 2.6 Create a collection with custom embedding function
 @pyseekdb.register_embedding_function
 class CustomEmbeddingFunction(pyseekdb.EmbeddingFunction):
     def __init__(self):
@@ -94,15 +90,15 @@ class CustomEmbeddingFunction(pyseekdb.EmbeddingFunction):
             pyseekdb.DefaultEmbeddingFunction()
         )  # use the default embedding function
 
-    def __call__(self, input: pyseekdb.Documents) -> pyseekdb.Embeddings:
+    def __call__(self, input):
         return self._ef(input)
 
     def get_config(self) -> dict:
         return self._ef.get_config()
 
     @staticmethod
-    def build_from_config(config: dict) -> "CustomEmbeddingFunction":
-        return CustomEmbeddingFunction(config=config)
+    def build_from_config(_config: dict) -> "CustomEmbeddingFunction":
+        return CustomEmbeddingFunction()
 
     @staticmethod
     def name() -> str:
@@ -110,10 +106,13 @@ class CustomEmbeddingFunction(pyseekdb.EmbeddingFunction):
 
 
 custom_ef = CustomEmbeddingFunction()
-collection3 = client.create_collection(
+collection3 = client.get_or_create_collection(
     name="custom_embedding_collection",
     embedding_function=custom_ef,
 )
+
+# 2.7 List all collections
+all_collections = client.list_collections()
 
 # ============================================================================
 # PART 3: DML OPERATIONS - ADD DATA
@@ -132,10 +131,7 @@ documents = [
 ]
 
 # Generate embeddings (in real usage, use an embedding model)
-embeddings = []
-for document in documents:
-    vector = default_ef(document)
-    embeddings.append(vector)
+embeddings = default_ef(documents)
 
 ids = [str(uuid.uuid4()) for _ in documents]
 
@@ -170,7 +166,7 @@ collection.add(
 vector_only_ids = [str(uuid.uuid4()) for _ in range(2)]
 collection.add(
     ids=vector_only_ids,
-    embeddings=[[random.random() for _ in range(dimension)] for _ in range(2)],
+    embeddings=default_ef([str(i) for i in range(2)]),
     metadatas=[{"type": "vector_only"}, {"type": "vector_only"}],
 )
 
@@ -191,10 +187,14 @@ collection.update(
 )
 
 # 4.2 Update multiple items
+update_documents = [
+    "Updated document 1",
+    "Updated document 2",
+]
 collection.update(
     ids=ids[1:3],
-    documents=["Updated document 1", "Updated document 2"],
-    embeddings=embeddings,
+    documents=update_documents,
+    embeddings=default_ef(update_documents),
     metadatas=[
         {"category": "Programming", "score": 95, "updated": True},
         {"category": "Database", "score": 97, "updated": True},
@@ -205,9 +205,8 @@ collection.update(
 update_documents = [
     "Search engines find relevant documents using semantic vectors",
     "Deep learning architectures are inspired by biological neurons",
-    "Text analytics empowers machines to interpret and extract meaning from language",
 ]
-update_embeddings = [default_ef(document) for document in update_documents]
+update_embeddings = default_ef(update_documents)
 collection.update(ids=ids[2:4], embeddings=update_embeddings)
 
 # ============================================================================
@@ -218,7 +217,7 @@ collection.update(ids=ids[2:4], embeddings=update_embeddings)
 collection.upsert(
     ids=ids[0],
     documents="Upserted document (was updated)",
-    embeddings=default_ef(document),
+    embeddings=default_ef("Upserted document (was updated)"),
     metadatas={"category": "AI", "upserted": True},
 )
 
@@ -228,7 +227,7 @@ new_document = "This is a new document from upsert"
 collection.upsert(
     ids=new_id,
     documents="This is a new document from upsert",
-    embeddings=default_ef(new_document),
+    embeddings=default_ef("This is a new document from upsert"),
     metadatas={"category": "New", "upserted": True},
 )
 
@@ -238,7 +237,7 @@ upsert_documents = [
     "Upserted document 1",
     "Upserted document 2",
 ]
-upsert_embeddings = [default_ef(document) for document in upsert_documents]
+upsert_embeddings = default_ef(upsert_documents)
 collection.upsert(
     ids=upsert_ids,
     documents=upsert_documents,

--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -23,15 +23,15 @@ logging.basicConfig(level=logging.DEBUG)
 # ============================================================================
 
 # Option 1: Embedded mode (local seekdb)
-# client = pyseekdb.Client(
-#     # path="./seekdb.db",
-#     # database="test"
-# )
+client = pyseekdb.Client(
+    # path="./seekdb.db",
+    # database="test"
+)
 
 # Option 2: Server mode (remote seekdb server)
-client = pyseekdb.Client(
-    host="6.12.233.133", port=10202, database="test", user="root", password=""
-)
+# client = pyseekdb.Client(
+#     host="127.0.0.1", port=2881, database="test", user="root", password=""
+# )
 
 # Option 3: Remote server mode (OceanBase Server)
 # client = pyseekdb.Client(

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -1357,6 +1357,10 @@ class BaseClient(BaseConnection, AdminAPI):
         #    - If embedding_function is provided, use it to generate embeddings from documents
         #    - If embedding_function is not provided, raise an error
         # 3. If neither embeddings nor documents are provided, raise an error
+        # NOTE: The embedding_function is passed through `get_collection` and `create_collection` parameters.
+        # If embedding_function parameter passed in `get_collection` and `create_collection` is None,
+        # then the embedding function is not provided. If developers passed through `_NOT_PROVIDED` (default value),
+        # then the embedding function is the default embedding function.
 
         if embeddings:
             # embeddings provided, use them directly without embedding

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -794,9 +794,10 @@ class BaseClient(BaseConnection, AdminAPI):
         self, name: str, embedding_function: EmbeddingFunctionParam = _NOT_PROVIDED
     ) -> "Collection":
         try:
-            collection = self._get_collection_v2(name, embedding_function)
-        except ValueError:
             collection = self._get_collection_v1(name, embedding_function)
+        except ValueError as e:
+            logger.debug(f"Failed to get collection v1: {e}, trying v2...")
+            collection = self._get_collection_v2(name, embedding_function)
         return collection
 
     def _resolve_collection_metadata_from_table(
@@ -932,9 +933,15 @@ class BaseClient(BaseConnection, AdminAPI):
             embedding_function_persistence is not None
             and not embedding_function is _NOT_PROVIDED
         ):
-            raise ValueError(
-                f"Both embedding function from parameter (not _NOT_PROVIDED, default value) and embedding function from persistence provided."
-            )
+            if (
+                embedding_function
+                and embedding_function_persistence.name() != embedding_function.name()
+            ):
+                raise ValueError(
+                    f"Both embedding function from parameter (not _NOT_PROVIDED, default value) and embedding function from persistence provided."
+                )
+            else:
+                return embedding_function_persistence
         if embedding_function is _NOT_PROVIDED:
             return (
                 embedding_function_persistence

--- a/tests/integration_tests/test_collection_dml.py
+++ b/tests/integration_tests/test_collection_dml.py
@@ -8,7 +8,6 @@ import time
 import uuid
 
 import pyseekdb
-from pyseekdb.client.meta_info import CollectionNames, CollectionFieldNames
 
 
 class TestCollectionDML:
@@ -22,23 +21,13 @@ class TestCollectionDML:
         """
         # Create test collection using execute
         collection_name = f"test_dml_{int(time.time() * 1000)}"
-        table_name = CollectionNames.table_name(collection_name)
         dimension = 3
 
-        # Create table using execute
-        create_table_sql = f"""CREATE TABLE `{table_name}` (
-            {CollectionFieldNames.ID} varbinary(512) PRIMARY KEY NOT NULL,
-            {CollectionFieldNames.DOCUMENT} string,
-            {CollectionFieldNames.EMBEDDING} vector({dimension}),
-            {CollectionFieldNames.METADATA} json,
-            FULLTEXT INDEX idx_fts({CollectionFieldNames.DOCUMENT}),
-            VECTOR INDEX idx_vec ({CollectionFieldNames.EMBEDDING}) with(distance=cosine, type=hnsw, lib=vsag)
-        ) ORGANIZATION = HEAP;"""
-        db_client._server._execute(create_table_sql)
-
         # Get collection object
-        collection = db_client.get_collection(
-            name=collection_name, embedding_function=None
+        collection = db_client.get_or_create_collection(
+            name=collection_name,
+            configuration=pyseekdb.HNSWConfiguration(dimension=dimension),
+            embedding_function=None,
         )
 
         # Test 1: collection.add - Add single item

--- a/tests/integration_tests/test_collection_embedding_function.py
+++ b/tests/integration_tests/test_collection_embedding_function.py
@@ -513,6 +513,18 @@ class TestCollectionEmbeddingFunction:
             f"   Embedding function model: {retrieved_collection.embedding_function.model_name}"
         )
 
+        collection_get = db_client.get_or_create_collection(
+            name=collection_name, embedding_function=custom_ef
+        )
+        assert collection_get is not None
+        assert collection_get.embedding_function is not None
+        assert collection_get.embedding_function == custom_ef
+        assert collection_get.dimension == 5
+        assert collection_get.name == collection_name
+        assert collection_get.configuration == config
+        assert collection_get.embedding_function.model_name == "my-test-model"
+        assert collection_get.embedding_function.dimension == 5
+
         # Cleanup
         try:
             db_client.delete_collection(name=collection_name)
@@ -606,6 +618,18 @@ class TestCollectionEmbeddingFunction:
             embeddings = retrieved_collection.embedding_function(["test"])
             assert len(embeddings) == 1
             assert len(embeddings[0]) == 4
+
+            collection_get = db_client.get_collection(
+                name=collection_name, embedding_function=custom_ef
+            )
+            assert collection_get is not None
+            assert collection_get.embedding_function is not None
+            assert collection_get.embedding_function == custom_ef
+            assert collection_get.dimension == 4
+            assert collection_get.name == collection_name
+            assert collection_get.configuration == config
+            assert collection_get.embedding_function.model_name == "custom-manual-model"
+            assert collection_get.embedding_function.dimension == 4
 
             print(f"   Successfully restored manually registered embedding function")
         finally:


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
close #120 
The embeddings in complete_example.py is generated by random which is confusing to users.
Now I change it to generated by the DefaultEmbeddingFunction and add a CustomEmbeddingFunction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in support for default and custom embedding functions and sample wiring for collection creation and DML flows.

* **Bug Fixes**
  * Replaced random embeddings with embedding-function-generated embeddings; improved collection retrieval with a fallback path.

* **Behavioral / API**
  * Introduced get-or-create collection flow and increased default embedding dimension to 384.

* **Documentation / Examples**
  * Updated example to show logging, embedding-function wiring, and collection enumeration.

* **Tests**
  * Expanded tests to verify persistence and restoration of custom embedding functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->