### PR TITLE
Test collection name more than 64 characters

### DIFF
--- a/tests/test_long_collection_name.py
+++ b/tests/test_long_collection_name.py
@@ -1,9 +1,8 @@
 """
 Test collection name length > 64 characters
-测试 collection name 长度超过 64 字符的情况
-
 Issue: https://github.com/oceanbase/pyseekdb/issues/121
 """
+import os
 import pytest
 from typing import List, Union
 
@@ -38,16 +37,19 @@ class TestLongCollectionName:
         "c" * 512,     # 512 字符（最大）
     ]
 
-    # 环境变量配置
-    SERVER_HOST = "biodev.cm.com"
-    SERVER_PORT = 2881
-    SERVER_DATABASE = "test"
-    SERVER_USER = "root"
-    SERVER_PASSWORD = ""
+    # Server configuration from environment variables
+    SERVER_HOST = os.environ.get("SEEKDB_HOST")
+    SERVER_PORT = int(os.environ.get("SEEKDB_PORT", "2881"))
+    SERVER_DATABASE = os.environ.get("SEEKDB_DATABASE", "test")
+    SERVER_USER = os.environ.get("SEEKDB_USER", "root")
+    SERVER_PASSWORD = os.environ.get("SEEKDB_PASSWORD", "")
 
     @pytest.fixture
     def server_client(self):
         """Create server mode client"""
+        if not self.SERVER_HOST:
+            pytest.skip("SEEKDB_HOST not configured, skipping remote server tests")
+
         import pyseekdb
         client = pyseekdb.Client(
             host=self.SERVER_HOST,
@@ -158,14 +160,3 @@ class TestLongCollectionName:
             assert len(collection.name) == length
             print(f"   Success: {name[:50]}...")
             server_client.delete_collection(name=name)
-
-
-if __name__ == "__main__":
-    print("\n" + "="*60)
-    print("pyseekdb - Long Collection Name Tests")
-    print("="*60)
-    print(f"\nEnvironment Configuration:")
-    print(f"  Server: {TestLongCollectionName.SERVER_HOST}:{TestLongCollectionName.SERVER_PORT}")
-    print(f"  Database: {TestLongCollectionName.SERVER_DATABASE}")
-    print("="*60 + "\n")
-    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_long_collection_name.py
+++ b/tests/test_long_collection_name.py
@@ -2,17 +2,20 @@
 Test collection name length > 64 characters
 Issue: https://github.com/oceanbase/pyseekdb/issues/121
 """
+
 import os
+from typing import ClassVar
+
 import pytest
-from typing import List, Union, ClassVar
 
 
 class Simple3DEmbeddingFunction:
     """Simple 3D embedding function for testing"""
+
     def __init__(self):
         self.dimension = 3
 
-    def __call__(self, docs: Union[str, List[str]]) -> List[List[float]]:
+    def __call__(self, docs: str | list[str]) -> list[list[float]]:
         if isinstance(docs, str):
             docs = [docs]
         embeddings = []
@@ -21,7 +24,7 @@ class Simple3DEmbeddingFunction:
             embedding = [
                 float((hash_val % 10) / 10.0),
                 float(((hash_val // 10) % 10) / 10.0),
-                float(((hash_val // 100) % 10) / 10.0)
+                float(((hash_val // 100) % 10) / 10.0),
             ]
             embeddings.append(embedding)
         return embeddings
@@ -31,10 +34,10 @@ class TestLongCollectionName:
     """Test collection operations with name > 64 chars"""
 
     # 测试用长名称
-    LONG_NAMES: ClassVar[List[str]] = [
-        "a" * 65,      # 边界值 + 1
-        "b" * 128,     # 128 字符
-        "c" * 512,     # 512 字符(最大)
+    LONG_NAMES: ClassVar[list[str]] = [
+        "a" * 65,  # 边界值 + 1
+        "b" * 128,  # 128 字符
+        "c" * 512,  # 512 字符(最大)
     ]
 
     # Server configuration from environment variables
@@ -51,98 +54,89 @@ class TestLongCollectionName:
             pytest.skip("SEEKDB_HOST not configured, skipping remote server tests")
 
         import pyseekdb
+
         client = pyseekdb.Client(
             host=self.SERVER_HOST,
             port=self.SERVER_PORT,
             tenant="sys",
             database=self.SERVER_DATABASE,
             user=self.SERVER_USER,
-            password=self.SERVER_PASSWORD
+            password=self.SERVER_PASSWORD,
         )
         yield client
 
     def test_create_collection_with_long_name(self, server_client):
         """Test create collection with name > 64 chars"""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("Testing create collection with long names (>64 chars)")
-        print("="*60)
+        print("=" * 60)
 
         for name in self.LONG_NAMES:
             print(f"\n✅ Creating collection with name length: {len(name)}")
-            collection = server_client.create_collection(
-                name=name,
-                embedding_function=Simple3DEmbeddingFunction()
-            )
+            collection = server_client.create_collection(name=name, embedding_function=Simple3DEmbeddingFunction())
             assert collection.name == name, f"Collection name mismatch: {collection.name} != {name}"
             print(f"   Created successfully: {name[:50]}...")
 
             # Cleanup
             server_client.delete_collection(name=name)
-            print(f"   Deleted successfully")
+            print("   Deleted successfully")
 
-    @pytest.mark.xfail(reason="Bug: get_or_create implementation uses collection name as table identifier, hitting DB limit (Issue #121)")
+    @pytest.mark.xfail(
+        reason="Bug: get_or_create implementation uses collection name as table identifier, hitting DB limit (Issue #121)"
+    )
     def test_get_or_create_collection_with_long_name(self, server_client):
         """Test get_or_create_collection with long name"""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("Testing get_or_create_collection with long names")
-        print("="*60)
+        print("=" * 60)
 
         name = "x" * 100
         print(f"\n✅ Testing get_or_create with name length: {len(name)}")
 
         # First creation
-        collection = server_client.get_or_create_collection(
-            name=name,
-            embedding_function=Simple3DEmbeddingFunction()
-        )
+        collection = server_client.get_or_create_collection(name=name, embedding_function=Simple3DEmbeddingFunction())
         assert collection.name == name
         print(f"   Created: {name[:50]}...")
 
         # Get existing
-        collection2 = server_client.get_or_create_collection(
-            name=name,
-            embedding_function=Simple3DEmbeddingFunction()
-        )
+        collection2 = server_client.get_or_create_collection(name=name, embedding_function=Simple3DEmbeddingFunction())
         assert collection2.name == name
-        print(f"   Retrieved existing collection successfully")
+        print("   Retrieved existing collection successfully")
 
         # Cleanup
         server_client.delete_collection(name=name)
-        print(f"   Cleaned up")
+        print("   Cleaned up")
 
     def test_delete_collection_with_long_name(self, server_client):
         """Test delete collection with long name"""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("Testing delete collection with long names")
-        print("="*60)
+        print("=" * 60)
 
         name = "y" * 200
         print(f"\n✅ Testing delete with name length: {len(name)}")
 
         # Create first
-        server_client.create_collection(
-            name=name,
-            embedding_function=Simple3DEmbeddingFunction()
-        )
-        print(f"   Created collection")
+        server_client.create_collection(name=name, embedding_function=Simple3DEmbeddingFunction())
+        print("   Created collection")
 
         # Verify exists
         assert server_client.has_collection(name=name)
-        print(f"   Verified collection exists")
+        print("   Verified collection exists")
 
         # Delete
         server_client.delete_collection(name=name)
-        print(f"   Deleted successfully")
+        print("   Deleted successfully")
 
         # Verify deleted
         assert not server_client.has_collection(name=name)
-        print(f"   Verified collection deleted")
+        print("   Verified collection deleted")
 
     def test_boundary_cases_long_name(self, server_client):
         """Test boundary cases: 64, 65, 512 characters"""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("Testing boundary cases (64, 65, 512 chars)")
-        print("="*60)
+        print("=" * 60)
 
         boundary_cases = [
             (64, "64 chars boundary"),
@@ -153,10 +147,7 @@ class TestLongCollectionName:
         for length, desc in boundary_cases:
             name = "a" * length
             print(f"\n✅ Testing name length: {len(name)} ({desc})")
-            collection = server_client.create_collection(
-                name=name,
-                embedding_function=Simple3DEmbeddingFunction()
-            )
+            collection = server_client.create_collection(name=name, embedding_function=Simple3DEmbeddingFunction())
             assert len(collection.name) == length
             print(f"   Success: {name[:50]}...")
             server_client.delete_collection(name=name)

--- a/tests/test_long_collection_name.py
+++ b/tests/test_long_collection_name.py
@@ -4,7 +4,7 @@ Issue: https://github.com/oceanbase/pyseekdb/issues/121
 """
 import os
 import pytest
-from typing import List, Union
+from typing import List, Union, ClassVar
 
 
 class Simple3DEmbeddingFunction:
@@ -12,11 +12,11 @@ class Simple3DEmbeddingFunction:
     def __init__(self):
         self.dimension = 3
 
-    def __call__(self, input: Union[str, List[str]]) -> List[List[float]]:
-        if isinstance(input, str):
-            input = [input]
+    def __call__(self, docs: Union[str, List[str]]) -> List[List[float]]:
+        if isinstance(docs, str):
+            docs = [docs]
         embeddings = []
-        for doc in input:
+        for doc in docs:
             hash_val = hash(doc) % 1000
             embedding = [
                 float((hash_val % 10) / 10.0),
@@ -31,10 +31,10 @@ class TestLongCollectionName:
     """Test collection operations with name > 64 chars"""
 
     # 测试用长名称
-    LONG_NAMES = [
+    LONG_NAMES: ClassVar[List[str]] = [
         "a" * 65,      # 边界值 + 1
         "b" * 128,     # 128 字符
-        "c" * 512,     # 512 字符（最大）
+        "c" * 512,     # 512 字符(最大)
     ]
 
     # Server configuration from environment variables

--- a/tests/test_long_collection_name.py
+++ b/tests/test_long_collection_name.py
@@ -1,0 +1,171 @@
+"""
+Test collection name length > 64 characters
+测试 collection name 长度超过 64 字符的情况
+
+Issue: https://github.com/oceanbase/pyseekdb/issues/121
+"""
+import pytest
+from typing import List, Union
+
+
+class Simple3DEmbeddingFunction:
+    """Simple 3D embedding function for testing"""
+    def __init__(self):
+        self.dimension = 3
+
+    def __call__(self, input: Union[str, List[str]]) -> List[List[float]]:
+        if isinstance(input, str):
+            input = [input]
+        embeddings = []
+        for doc in input:
+            hash_val = hash(doc) % 1000
+            embedding = [
+                float((hash_val % 10) / 10.0),
+                float(((hash_val // 10) % 10) / 10.0),
+                float(((hash_val // 100) % 10) / 10.0)
+            ]
+            embeddings.append(embedding)
+        return embeddings
+
+
+class TestLongCollectionName:
+    """Test collection operations with name > 64 chars"""
+
+    # 测试用长名称
+    LONG_NAMES = [
+        "a" * 65,      # 边界值 + 1
+        "b" * 128,     # 128 字符
+        "c" * 512,     # 512 字符（最大）
+    ]
+
+    # 环境变量配置
+    SERVER_HOST = "biodev.cm.com"
+    SERVER_PORT = 2881
+    SERVER_DATABASE = "test"
+    SERVER_USER = "root"
+    SERVER_PASSWORD = ""
+
+    @pytest.fixture
+    def server_client(self):
+        """Create server mode client"""
+        import pyseekdb
+        client = pyseekdb.Client(
+            host=self.SERVER_HOST,
+            port=self.SERVER_PORT,
+            tenant="sys",
+            database=self.SERVER_DATABASE,
+            user=self.SERVER_USER,
+            password=self.SERVER_PASSWORD
+        )
+        yield client
+
+    def test_create_collection_with_long_name(self, server_client):
+        """Test create collection with name > 64 chars"""
+        print("\n" + "="*60)
+        print("Testing create collection with long names (>64 chars)")
+        print("="*60)
+
+        for name in self.LONG_NAMES:
+            print(f"\n✅ Creating collection with name length: {len(name)}")
+            collection = server_client.create_collection(
+                name=name,
+                embedding_function=Simple3DEmbeddingFunction()
+            )
+            assert collection.name == name, f"Collection name mismatch: {collection.name} != {name}"
+            print(f"   Created successfully: {name[:50]}...")
+
+            # Cleanup
+            server_client.delete_collection(name=name)
+            print(f"   Deleted successfully")
+
+    @pytest.mark.xfail(reason="Bug: get_or_create implementation uses collection name as table identifier, hitting DB limit (Issue #121)")
+    def test_get_or_create_collection_with_long_name(self, server_client):
+        """Test get_or_create_collection with long name"""
+        print("\n" + "="*60)
+        print("Testing get_or_create_collection with long names")
+        print("="*60)
+
+        name = "x" * 100
+        print(f"\n✅ Testing get_or_create with name length: {len(name)}")
+
+        # First creation
+        collection = server_client.get_or_create_collection(
+            name=name,
+            embedding_function=Simple3DEmbeddingFunction()
+        )
+        assert collection.name == name
+        print(f"   Created: {name[:50]}...")
+
+        # Get existing
+        collection2 = server_client.get_or_create_collection(
+            name=name,
+            embedding_function=Simple3DEmbeddingFunction()
+        )
+        assert collection2.name == name
+        print(f"   Retrieved existing collection successfully")
+
+        # Cleanup
+        server_client.delete_collection(name=name)
+        print(f"   Cleaned up")
+
+    def test_delete_collection_with_long_name(self, server_client):
+        """Test delete collection with long name"""
+        print("\n" + "="*60)
+        print("Testing delete collection with long names")
+        print("="*60)
+
+        name = "y" * 200
+        print(f"\n✅ Testing delete with name length: {len(name)}")
+
+        # Create first
+        server_client.create_collection(
+            name=name,
+            embedding_function=Simple3DEmbeddingFunction()
+        )
+        print(f"   Created collection")
+
+        # Verify exists
+        assert server_client.has_collection(name=name)
+        print(f"   Verified collection exists")
+
+        # Delete
+        server_client.delete_collection(name=name)
+        print(f"   Deleted successfully")
+
+        # Verify deleted
+        assert not server_client.has_collection(name=name)
+        print(f"   Verified collection deleted")
+
+    def test_boundary_cases_long_name(self, server_client):
+        """Test boundary cases: 64, 65, 512 characters"""
+        print("\n" + "="*60)
+        print("Testing boundary cases (64, 65, 512 chars)")
+        print("="*60)
+
+        boundary_cases = [
+            (64, "64 chars boundary"),
+            (65, "65 chars (boundary + 1)"),
+            (512, "512 chars (max)"),
+        ]
+
+        for length, desc in boundary_cases:
+            name = "a" * length
+            print(f"\n✅ Testing name length: {len(name)} ({desc})")
+            collection = server_client.create_collection(
+                name=name,
+                embedding_function=Simple3DEmbeddingFunction()
+            )
+            assert len(collection.name) == length
+            print(f"   Success: {name[:50]}...")
+            server_client.delete_collection(name=name)
+
+
+if __name__ == "__main__":
+    print("\n" + "="*60)
+    print("pyseekdb - Long Collection Name Tests")
+    print("="*60)
+    print(f"\nEnvironment Configuration:")
+    print(f"  Server: {TestLongCollectionName.SERVER_HOST}:{TestLongCollectionName.SERVER_PORT}")
+    print(f"  Database: {TestLongCollectionName.SERVER_DATABASE}")
+    print("="*60 + "\n")
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
Issue: https://github.com/oceanbase/pyseekdb/issues/121

- Add tests for collection names with 65, 128, and 512 characters
- Cover create, get_or_create, and delete operations
- Test boundary cases (64, 65, 512 chars)
- Mark get_or_create test as xfail due to underlying table identifier limit bug

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->
## Test collection name more than 64 characters

### Issue
https://github.com/oceanbase/pyseekdb/issues/121

### Track
Track 8 — seekdb, pyseekdb (Mentor: @hnwyllmm)

### Changes
- Added `tests/test_long_collection_name.py` with comprehensive tests for collection names exceeding 64 characters.
- Tested collection names with 65, 128, and 512 characters.
- Covered create, get_or_create, and delete operations.
- Verified boundary cases (64, 65, 512 chars).

### Findings & Bug Report 🐛
While writing these tests, I discovered that **`get_or_create_collection` fails with long names**.
- `create_collection`: ✅ Works perfectly with names > 64 chars.
- `get_or_create_collection`: ❌ Fails with `OperationalError: (1059, "Identifier name ... is too long")`.
- **Reason**: It seems `get_or_create` still uses the raw collection name as the table identifier, hitting the DB's 64-char limit, whereas `create` correctly uses the new metadata mapping mechanism.
- **Action**: I have marked this specific test case as `@pytest.mark.xfail` to allow the test suite to pass while highlighting the issue.

### Testing
- All tests passed (3 passed, 1 xfailed).
- Verified against a remote seekdb server.

### AI Contribution Details 🤖
This PR was entirely implemented by an AI Agent (Claude Code) under human supervision.
1. **Analysis**: Parsed the task guide and identified requirements.
2. **Environment**: Setup `uv` virtual environment and installed dependencies via proxy.
3. **Implementation**: Wrote `tests/test_long_collection_name.py` covering all edge cases.
4. **Validation**: Ran tests against a live `seekdb` server.
5. **Bug Discovery**: The AI agent independently identified the `get_or_create` bug via test failures, analyzed the `pymysql` stack trace, and applied `@pytest.mark.xfail` to handle it gracefully without blocking CI.
## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for handling collection names exceeding 64 characters, including boundary case validation.
  * Documented a known issue with the get_or_create method for long collection names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->