### PR TITLE
feat: support multi-version docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,19 @@ test-integration-embedded: ## Run embedded integration tests
 	@$(UV) run pytest tests/integration_tests/ -v --log-cli-level=INFO -k embedded
 
 .PHONY: docs
-docs: ## Build documentation
+docs: ## Build documentation (single version)
 	@echo ">> Building documentation"
 	@$(UV) run sphinx-build -b html docs docs/_build/html
+
+.PHONY: docs-multiversion
+docs-multiversion: ## Build multi-version documentation
+	@echo ">> Building multi-version documentation"
+	@bash docs/build_multiversion.sh
+
+.PHONY: docs-serve
+docs-serve: ## Serve documentation with auto-reload
+	@echo ">> Starting documentation server"
+	@$(UV) run sphinx-autobuild docs docs/_build/html --host 127.0.0.1 --port 8000
 
 .PHONY: build
 build: ## Build package

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,66 @@
+/* 版本选择器下拉框样式 - 放在左侧导航栏搜索框下方 */
+.version-selector-dropdown {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    border-radius: 50px;
+}
+
+.version-selector-dropdown label {
+    font-size: 13px;
+    font-weight: 600;
+    color: #fff;
+    margin: 0;
+    white-space: nowrap;
+}
+
+.version-selector-dropdown select {
+    flex: 1;
+    padding: 6px 10px;
+    font-size: 13px;
+    color: #404040;
+    background-color: #fff;
+    border: 1px solid #d0d0d0;
+    border-radius: 4px;
+    cursor: pointer;
+    outline: none;
+    transition: all 0.2s ease;
+}
+
+.version-selector-dropdown select:hover {
+    border-color: #2980b9;
+}
+
+.version-selector-dropdown select:focus {
+    border-color: #2980b9;
+    box-shadow: 0 0 0 2px rgba(41, 128, 185, 0.1);
+}
+
+/* RTD 主题版本横幅样式 - 隐藏左下角的版本选择器 */
+.rst-versions {
+    display: none !important;
+}
+
+/* 版本警告横幅 */
+.version-warning {
+    padding: 10px 15px;
+    margin-bottom: 20px;
+    background-color: #fff3cd;
+    border: 1px solid #ffeaa7;
+    border-radius: 4px;
+    color: #856404;
+}
+
+.version-warning strong {
+    font-weight: bold;
+}
+
+.version-warning a {
+    color: #856404;
+    text-decoration: underline;
+}
+
+.version-warning a:hover {
+    color: #533f03;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,18 @@
+{% extends "!layout.html" %}
+
+{# 在左侧导航栏的搜索框下方插入版本选择器 #}
+{% block sidebartitle %}
+  {{ super() }}
+  {% if versions %}
+  <div class="version-selector-dropdown">
+    <label for="version-select">版本:</label>
+    <select id="version-select" onchange="window.location.href=this.value">
+      {% for item in versions %}
+      <option value="{{ item.url }}" {% if item.name == current_version %}selected{% endif %}>
+        {{ item.name }}{% if item.name == current_version %} (当前){% elif item.is_released %} (稳定){% endif %}
+      </option>
+      {% endfor %}
+    </select>
+  </div>
+  {% endif %}
+{% endblock %}

--- a/docs/build_multiversion.sh
+++ b/docs/build_multiversion.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# 构建多版本文档的脚本
+
+set -e
+
+# 颜色输出
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}开始构建多版本文档...${NC}"
+
+# 确保在项目根目录
+cd "$(dirname "$0")/.."
+
+# 激活虚拟环境（如果存在）
+if [ -d ".venv" ]; then
+    echo -e "${GREEN}激活虚拟环境...${NC}"
+    source .venv/bin/activate
+fi
+
+# 清理旧的构建文件
+echo -e "${GREEN}清理旧的构建文件...${NC}"
+rm -rf docs/_build/html
+
+# 使用 sphinx-multiversion 构建文档
+echo -e "${GREEN}使用 sphinx-multiversion 构建文档...${NC}"
+sphinx-multiversion docs docs/_build/html
+
+# 创建重定向到最新版本的 index.html
+echo -e "${GREEN}创建重定向页面...${NC}"
+cat > docs/_build/html/index.html << 'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Redirecting to latest version</title>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=./develop/index.html">
+  <link rel="canonical" href="./develop/index.html">
+</head>
+<body>
+  <p>Redirecting to <a href="./develop/index.html">latest version</a>...</p>
+</body>
+</html>
+EOF
+
+echo -e "${BLUE}多版本文档构建完成！${NC}"
+echo -e "${GREEN}文档位置: docs/_build/html${NC}"
+echo -e "${GREEN}可以使用以下命令启动本地服务器查看:${NC}"
+echo -e "  cd docs/_build/html && python -m http.server 8000"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,24 +61,24 @@ exclude_patterns = ["_build"]
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 html_css_files = [
-    'custom.css',
+    "custom.css",
 ]
 
 # Sphinx-multiversion configuration
 # 配置要包含的分支和标签
-smv_tag_whitelist = r'^v\d+\.\d+\.\d+$'  # 匹配 v1.0.0 格式的标签
-smv_branch_whitelist = r'^(main|develop)$'  # 包含 main 和 develop 分支
-smv_remote_whitelist = r'^origin$'  # 只使用 origin 远程仓库
-smv_released_pattern = r'^refs/tags/.*$'  # 标记已发布的版本
+smv_tag_whitelist = r"^v\d+\.\d+\.\d+$"  # 匹配 v1.0.0 格式的标签
+smv_branch_whitelist = r"^(main|develop)$"  # 包含 main 和 develop 分支
+smv_remote_whitelist = r"^origin$"  # 只使用 origin 远程仓库
+smv_released_pattern = r"^refs/tags/.*$"  # 标记已发布的版本
 
 # 自定义模板路径
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # 版本横幅配置
 html_context = {
-    'display_github': True,
-    'github_user': 'oceanbase',
-    'github_repo': 'pyseekdb',
-    'github_version': 'develop',
-    'conf_py_path': '/docs/',
+    "display_github": True,
+    "github_user": "oceanbase",
+    "github_repo": "pyseekdb",
+    "github_version": "develop",
+    "conf_py_path": "/docs/",
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "myst_parser",
+    "sphinx_multiversion",
 ]
 
 # Enable Markdown in docstrings
@@ -59,3 +60,25 @@ exclude_patterns = ["_build"]
 # HTML theme
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+html_css_files = [
+    'custom.css',
+]
+
+# Sphinx-multiversion configuration
+# 配置要包含的分支和标签
+smv_tag_whitelist = r'^v\d+\.\d+\.\d+$'  # 匹配 v1.0.0 格式的标签
+smv_branch_whitelist = r'^(main|develop)$'  # 包含 main 和 develop 分支
+smv_remote_whitelist = r'^origin$'  # 只使用 origin 远程仓库
+smv_released_pattern = r'^refs/tags/.*$'  # 标记已发布的版本
+
+# 自定义模板路径
+templates_path = ['_templates']
+
+# 版本横幅配置
+html_context = {
+    'display_github': True,
+    'github_user': 'oceanbase',
+    'github_repo': 'pyseekdb',
+    'github_version': 'develop',
+    'conf_py_path': '/docs/',
+}


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
close #104
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
1. 多版本文档构建系统
- 集成 sphinx-multiversion 扩展，支持为多个分支和标签构建文档
- 配置了版本白名单规则：
  - 标签格式：v *.*.*（如 v1.0.0, v1.1.0）
  - 分支：main 和 develop
- 自动创建重定向页面，默认跳转到 develop 版本
2. Makefile 新增命令
- `make docs-multiversion`：构建所有版本的文档
- `make docs-serve`：启动支持自动重载的开发服务器
- `make docs`：单版本构建（已更新注释）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-version documentation build and a local doc server with auto-reload for live previews
  * Version selector dropdown in the docs UI to switch between documentation versions

* **Documentation**
  * New styling and banners for version-aware documentation and a redirect to the latest version for easy access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->