### PR TITLE
support more options of hnsw index config

### DIFF
--- a/src/pyseekdb/__init__.py
+++ b/src/pyseekdb/__init__.py
@@ -60,11 +60,11 @@ Admin client - Database management:
 
 import importlib.metadata
 
-# Note: pylibseekdb built with ABI=0 and torch built with ABI=1, so there's a conflict between the two libraries.
+# Note: pylibseekdb built with ABI=0 and onnxruntime built with ABI=1, so there's a conflict between the two libraries.
 # pylibseekdb is built both with ABI=0 and the -Bsymbolic flag, so we can load libraries with ABI=1 first
 # and then pylibseekdb to avoid these conflicts.
-if importlib.util.find_spec("torch"):
-    import torch  # noqa: F401
+if importlib.util.find_spec("onnxruntime"):
+    import onnxruntime  # noqa: F401
 
 from .client import (
     AdminAPI,

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -156,7 +156,16 @@ def _get_vector_index_sql(hnsw_config: HNSWConfiguration) -> str:
     """
     Generate VECTOR INDEX SQL clause from HNSWConfiguration.
     """
-    return f"WITH (DISTANCE={hnsw_config.distance}, TYPE=hnsw, LIB=vsag)"
+    properties = hnsw_config.properties or {}
+    property_parts = []
+    for k, v in properties.items():
+        if isinstance(v, str):
+            property_parts.append(f"{k}='{v}'")
+        else:
+            property_parts.append(f"{k}={v}")
+    property_str = ", ".join(property_parts)
+    properties_str = f", {property_str}" if property_str else ""
+    return f"WITH (DISTANCE={hnsw_config.distance}, TYPE=hnsw, LIB=vsag{properties_str})"
 
 
 def _embedding_to_hexstring(embedding: list[float]) -> str:

--- a/src/pyseekdb/client/configuration.py
+++ b/src/pyseekdb/client/configuration.py
@@ -61,10 +61,10 @@ class HNSWConfiguration:
             for value in self.properties.values():
                 if not isinstance(value, (str, int, float, bool)):
                     raise TypeError(f"properties must be a dictionary of string, int, float, or bool, got {value}")
-            for key in self.properties:
-                if key.lower() == "distance":
-                    warnings.warn(f"{key} is a reserved keyword in properties, it will be ignored", stacklevel=2)
-                    self.properties.pop(key)
+            distance_keys = [key for key in self.properties if key.lower() == "distance"]
+            for key in distance_keys:
+                warnings.warn(f"{key} is a reserved keyword in properties, it will be ignored", stacklevel=2)
+                self.properties.pop(key)
 
 
 class Configuration:

--- a/src/pyseekdb/client/configuration.py
+++ b/src/pyseekdb/client/configuration.py
@@ -61,9 +61,10 @@ class HNSWConfiguration:
             for value in self.properties.values():
                 if not isinstance(value, (str, int, float, bool)):
                     raise TypeError(f"properties must be a dictionary of string, int, float, or bool, got {value}")
-            if "distance" in {key.lower() for key in self.properties}:
-                warnings.warn("distance is a reserved keyword in properties, it will be ignored", stacklevel=2)
-                self.properties.pop("distance")
+            for key in self.properties:
+                if key.lower() == "distance":
+                    warnings.warn(f"{key} is a reserved keyword in properties, it will be ignored", stacklevel=2)
+                    self.properties.pop(key)
 
 
 class Configuration:

--- a/src/pyseekdb/client/configuration.py
+++ b/src/pyseekdb/client/configuration.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 
@@ -46,6 +47,7 @@ class HNSWConfiguration:
 
     dimension: int
     distance: str = DistanceMetric.L2.value
+    properties: dict[str, str | int | float | bool] | None = None
 
     def __post_init__(self):
         if self.dimension <= 0:
@@ -53,6 +55,13 @@ class HNSWConfiguration:
         valid_distances = [e.value for e in DistanceMetric]
         if self.distance not in valid_distances:
             raise ValueError(f"distance must be one of {valid_distances}, got {self.distance}")
+        if self.properties:
+            for value in self.properties.values():
+                if not isinstance(value, (str, int, float, bool)):
+                    raise TypeError(f"properties must be a dictionary of string, int, float, or bool, got {value}")
+            if "distance" in {key.lower() for key in self.properties}:
+                warnings.warn("distance is a reserved keyword in properties, it will be ignored", stacklevel=2)
+                self.properties.pop("distance")
 
 
 class Configuration:

--- a/src/pyseekdb/client/configuration.py
+++ b/src/pyseekdb/client/configuration.py
@@ -43,6 +43,8 @@ class HNSWConfiguration:
     Args:
         dimension: Vector dimension (number of elements in each vector)
         distance: Distance metric for similarity calculation (e.g., 'l2', 'cosine', 'inner_product')
+        properties: Optional dictionary of properties for the HNSW index (key: string, value: primitive type)
+        Please refer to [HNSW configuration](https://en.oceanbase.com/docs/common-oceanbase-database-10000000003351043) for detailed information.
     """
 
     dimension: int

--- a/tests/integration_tests/test_client_creation.py
+++ b/tests/integration_tests/test_client_creation.py
@@ -45,7 +45,9 @@ class TestClientCreation:
         # Test: Verify Configuration class with fulltext parser works
         test_collection_name_config = f"test_collection_config_{int(time.time() * 1000)}"
         config_with_fulltext = Configuration(
-            hnsw=HNSWConfiguration(dimension=test_dimension, distance="cosine"),
+            hnsw=HNSWConfiguration(
+                dimension=test_dimension, distance="cosine", properties={"M": 16, "ef_construction": 400}
+            ),
             fulltext_config=FulltextIndexConfig(analyzer="ik"),
         )
         collection_config = db_client.create_collection(

--- a/tests/unit_tests/test_configuration.py
+++ b/tests/unit_tests/test_configuration.py
@@ -12,6 +12,7 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from pyseekdb import Configuration, FulltextIndexConfig, HNSWConfiguration  # noqa: E402
+from pyseekdb.client.client_base import _get_vector_index_sql  # noqa: E402
 
 
 class TestHNSWConfiguration:
@@ -40,6 +41,69 @@ class TestHNSWConfiguration:
         """Test that invalid distance raises ValueError"""
         with pytest.raises(ValueError, match="distance must be one of"):
             HNSWConfiguration(dimension=128, distance="invalid")
+
+    def test_properties_with_primitive_types(self):
+        """Test properties with primitive value types"""
+        config = HNSWConfiguration(
+            dimension=128,
+            properties={
+                "m": 16,
+                "ef_search": 200,
+                "ef_construction": 400,
+                "normalize": True,
+                "quantization": "pq",
+                "alpha": 0.75,
+            },
+        )
+        assert config.properties["m"] == 16
+        assert config.properties["ef_search"] == 200
+        assert config.properties["ef_construction"] == 400
+        assert config.properties["normalize"] is True
+        assert config.properties["quantization"] == "pq"
+        assert config.properties["alpha"] == 0.75
+
+    def test_properties_invalid_type(self):
+        """Test properties with invalid value types"""
+        with pytest.raises(ValueError, match="properties must be a dictionary of string, int, float, or bool"):
+            HNSWConfiguration(
+                dimension=128,
+                properties={
+                    "m": 16,
+                    "invalid": {"nested": "dict"},
+                },
+            )
+
+    def test_properties_reserved_distance(self):
+        """Test that distance is removed from properties with warning"""
+        with pytest.warns(UserWarning, match="distance is a reserved keyword"):
+            config = HNSWConfiguration(
+                dimension=128,
+                properties={
+                    "distance": "cosine",
+                    "M": 32,
+                },
+            )
+        assert "distance" not in {key.lower() for key in config.properties}
+        assert config.properties["M"] == 32
+
+    def test_vector_index_sql_with_properties(self):
+        """Test SQL generation includes properties"""
+        config = HNSWConfiguration(
+            dimension=128,
+            distance="cosine",
+            properties={
+                "M": 16,
+                "ef_search": 200,
+                "quantization": "pq",
+            },
+        )
+        sql = _get_vector_index_sql(config)
+        assert "DISTANCE=cosine" in sql
+        assert "TYPE=hnsw" in sql
+        assert "LIB=vsag" in sql
+        assert "M=16" in sql
+        assert "ef_search=200" in sql
+        assert "quantization='pq'" in sql
 
 
 class TestFulltextIndexConfig:

--- a/tests/unit_tests/test_configuration.py
+++ b/tests/unit_tests/test_configuration.py
@@ -64,7 +64,7 @@ class TestHNSWConfiguration:
 
     def test_properties_invalid_type(self):
         """Test properties with invalid value types"""
-        with pytest.raises(ValueError, match="properties must be a dictionary of string, int, float, or bool"):
+        with pytest.raises(TypeError, match="properties must be a dictionary of string, int, float, or bool"):
             HNSWConfiguration(
                 dimension=128,
                 properties={


### PR DESCRIPTION

## Summary
close #165 
Support more options of HNSW index config.

Use dict type, `properties` of HNSWConfiguration, to support other options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HNSW index supports customizable properties (e.g., M, ef_construction, ef_search, quantization) via an optional properties map.

* **Improvements**
  * Runtime dependency handling switched from torch to onnxruntime.
  * Reserved configuration keywords (like distance) are detected, removed, and emit a warning.

* **Tests**
  * Added tests for property validation, reserved-key handling, and SQL generation including properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->