### PR TITLE
fix openmp conflict between pylibseekdb and pytorch

### DIFF
--- a/examples/sparse_vector_index_example.py
+++ b/examples/sparse_vector_index_example.py
@@ -1,10 +1,23 @@
+################################################################################
+# Sparse Vector Index Example
+# install dependencies first:
+# pip install "bm25s[full]" sentence-transformers
+# Note: bm25s[full] is used for bm25 embedding function,
+# sentence-transformers is used for hugging face embedding function and
+# reranking with model
+################################################################################
+
 from __future__ import annotations
 
 import contextlib
 from typing import Any, Literal
 
+from transformers.utils import logging as hf_logging
+
 from pyseekdb import Client, HNSWConfiguration, K, Schema, SparseVectorIndexConfig
 from pyseekdb.utils.embedding_functions import BM25SparseEmbeddingFunction
+
+hf_logging.set_verbosity_error()
 
 # 1. Initialize client (Embedded mode; creates seekdb.db in the current directory)
 client = Client()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,9 +113,6 @@ ignore = [
 [tool.ruff.format]
 preview = true
 
-[project.scripts]
-pyseekdb = "pyseekdb.cli:main"
-
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"

--- a/src/pyseekdb/__init__.py
+++ b/src/pyseekdb/__init__.py
@@ -66,6 +66,10 @@ import importlib.metadata
 if importlib.util.find_spec("onnxruntime"):
     import onnxruntime  # noqa: F401
 
+# torch and pylibseekdb both use openmp library, which is conflict on macos.
+if importlib.util.find_spec("torch"):
+    import torch  # noqa: F401
+
 from .client import (
     AdminAPI,
     AdminClient,


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
On macos, both pylibseekdb and pytorch are using openmp. pylibseekdb link openmp library in static mode and pytorch link openmp in dynamic mode. When we load pylibseekdb first and then pytorch, it failed with segment fault. I have tried change the linkage mode of openmp in pylibseekdb to dynamic, but it still failed. But if we load pytorch/torch first, it works well. So I import torch if exists in the `__init__.py`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved library compatibility on macOS to prevent potential conflicts during execution.
  * Reduced verbose logging output when running example scripts.

* **Chores**
  * Removed the `pyseekdb` console command entry point from package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->