### PR TITLE
fix: map duplicate destination fork_database error to ValueError

### DIFF
--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -595,7 +595,17 @@ class BaseClient(BaseConnection, AdminAPI):
         effective_tenant = self._database_tenant(tenant)
         logger.debug(f"Forking database: {source_name} -> {destination_name}{self._database_context(effective_tenant)}")
         sql = f"FORK DATABASE `{source_name}` TO `{destination_name}`"
-        self._execute(sql)
+        try:
+            self._execute(sql)
+        except Exception as ex:
+            args = getattr(ex, "args", ())
+            if args and isinstance(args[0], int) and args[0] == 1007:
+                raise ValueError(f"Database '{destination_name}' already exists") from ex
+
+            msg = str(ex).lower()
+            if ("database exists" in msg or "already exists" in msg) and "database" in msg:
+                raise ValueError(f"Database '{destination_name}' already exists") from ex
+            raise
         logger.debug(f"✅ Successfully forked database '{source_name}' to '{destination_name}'")
         return self.get_database(destination_name, tenant=tenant)
 


### PR DESCRIPTION
## Summary
- handle duplicate destination database errors in `BaseClient.fork_database` by converting MySQL/SeekDB error `1007` to `ValueError`
- keep unrelated SQL exceptions unchanged
- fix integration behavior so destination-exists scenario surfaces SDK-level error consistently

Closes #189.

## Test plan
- [x] Reproduced failure against remote server:
  - `SERVER_HOST=11.161.204.175 SERVER_PORT=2881 .venv3/bin/python3 -m pytest tests/integration_tests/test_database_fork.py::TestDatabaseFork::test_fork_database_destination_already_exists -k server -q`
  - before fix: failed with `pymysql.err.ProgrammingError (1007)`
- [x] Verified after fix with same command:
  - `1 passed, 2 deselected`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for database forking operations. The application now properly detects and reports when a destination database already exists, providing clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->