### PR TITLE
change some doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Key features:
 
 ## Documentation
 
-- Docs home: https://oceanbase.github.io/pyseekdb/
-- User guide: https://oceanbase.github.io/pyseekdb/guide/
-- API reference: https://oceanbase.github.io/pyseekdb/api/
+- Docs home: https://docs.seekdb.ai/seekdb/seekdb-overview/
+- User guide: https://docs.seekdb.ai/seekdb/deploy-overview
+- API reference: https://docs.seekdb.ai/seekdb/api-overview
 - RAG demo: [English](demo/rag/README.md) / [中文](demo/rag/README_CN.md)
 - Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/oceanbase/pyseekdb/"
+Homepage = "https://www.seekdb.ai/"
 Repository = "https://github.com/oceanbase/pyseekdb/"
 "Bug Tracker" = "https://github.com/oceanbase/pyseekdb/issues"
 


### PR DESCRIPTION
This pull request updates documentation links and project metadata to point to the new SeekDB domain, ensuring users access the most up-to-date resources.

**Documentation updates:**
* Updated all documentation links in `README.md` to use the new `docs.seekdb.ai` domain for the docs home, user guide, and API reference.

**Project metadata:**
* Changed the `Homepage` URL in `pyproject.toml` to `https://www.seekdb.ai/` to reflect the new official site.<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to direct to new SeekDB documentation resources (home, user guide, and API reference)

* **Chores**
  * Updated project homepage URL to seekdb.ai

<!-- end of auto-generated comment: release notes by coderabbit.ai -->