### PR TITLE
Adapt [vector_async_index] add collection.flush_index()

### DIFF
--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -1504,6 +1504,12 @@ class BaseClient(BaseConnection, AdminAPI):
         logger.debug(f"db_type: {db_type}, version: {version}")
         return db_type.lower() == "seekdb" and version >= version_120
 
+    def _refresh_enabled(self) -> bool:
+        db_type, version = self.detect_db_type_and_version()
+        version_130 = Version("1.3.0.0")
+        logger.debug(f"db_type: {db_type}, version: {version}")
+        return db_type.lower() == "seekdb" and version >= version_130
+
     def _get_collection_id(self, collection_name: str) -> str:
         collection_id_query_sql = f"SELECT COLLECTION_ID FROM `{CollectionNames.sdk_collections_table_name()}` WHERE COLLECTION_NAME = '{collection_name}'"
         collection_id_query_result = self._execute(collection_id_query_sql)

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -1510,6 +1510,18 @@ class BaseClient(BaseConnection, AdminAPI):
         logger.debug(f"db_type: {db_type}, version: {version}")
         return db_type.lower() == "seekdb" and version >= version_130
 
+    def refresh_index(self) -> None:
+        """
+        Flush async vector index build tasks when supported.
+
+        For unsupported database versions, this method is a no-op to keep
+        collection-level API calls backward compatible.
+        """
+        if not self._refresh_enabled():
+            return
+
+        self._execute("CALL dbms_index_manager.refresh();")
+
     def _get_collection_id(self, collection_name: str) -> str:
         collection_id_query_sql = f"SELECT COLLECTION_ID FROM `{CollectionNames.sdk_collections_table_name()}` WHERE COLLECTION_NAME = '{collection_name}'"
         collection_id_query_result = self._execute(collection_id_query_sql)

--- a/src/pyseekdb/client/collection.py
+++ b/src/pyseekdb/client/collection.py
@@ -593,6 +593,15 @@ class Collection:
             **kwargs,
         )
 
+    def flush(self) -> None:
+        """
+        Flush async vector index build tasks.
+
+        This executes ``CALL dbms_index_manager.refresh();`` and returns only
+        after the database completes the refresh procedure.
+        """
+        self._client._execute("CALL dbms_index_manager.refresh();")
+
     # ==================== Collection Info ====================
 
     def count(self) -> int:

--- a/src/pyseekdb/client/collection.py
+++ b/src/pyseekdb/client/collection.py
@@ -115,6 +115,30 @@ class Collection:
     def __repr__(self) -> str:
         return f"Collection(name='{self._name}', dimension={self._dimension}, client={self._client.mode})"
 
+    def __getattribute__(self, name: str):
+        # Hide refresh for unsupported database versions to keep public surface
+        # consistent with server capabilities.
+        if name == "refresh":
+            is_refresh_available = object.__getattribute__(self, "_is_refresh_available")
+            if not is_refresh_available():
+                raise AttributeError("'Collection' object has no attribute 'refresh'")
+        return object.__getattribute__(self, name)
+
+    def __dir__(self) -> list[str]:
+        attrs = super().__dir__()
+        if "refresh" in attrs and not self._is_refresh_available():
+            attrs.remove("refresh")
+        return attrs
+
+    def _is_refresh_available(self) -> bool:
+        checker = getattr(self._client, "_refresh_enabled", None)
+        if callable(checker):
+            try:
+                return bool(checker())
+            except Exception:
+                return False
+        return True
+
     def fork(self, forked_name: str) -> "Collection":
         """
         Fork (duplicate) this collection to create a new collection with the same data.
@@ -599,7 +623,13 @@ class Collection:
 
         This executes ``CALL dbms_index_manager.refresh();`` and returns only
         after the database completes the refresh procedure.
+
+        Note:
+            This method is only available for seekdb version 1.3.0.0 or higher.
+            In 1.2.0.0 and earlier, this method is hidden from the collection API.
         """
+        if not self._is_refresh_available():
+            raise AttributeError("'Collection' object has no attribute 'refresh'")
         self._client._execute("CALL dbms_index_manager.refresh();")
 
     # ==================== Collection Info ====================

--- a/src/pyseekdb/client/collection.py
+++ b/src/pyseekdb/client/collection.py
@@ -137,7 +137,8 @@ class Collection:
                 return bool(checker())
             except Exception:
                 return False
-        return True
+        # Fail closed: if capability detection is unavailable, treat refresh as unsupported.
+        return False
 
     def fork(self, forked_name: str) -> "Collection":
         """

--- a/src/pyseekdb/client/collection.py
+++ b/src/pyseekdb/client/collection.py
@@ -116,18 +116,18 @@ class Collection:
         return f"Collection(name='{self._name}', dimension={self._dimension}, client={self._client.mode})"
 
     def __getattribute__(self, name: str):
-        # Hide refresh for unsupported database versions to keep public surface
+        # Hide refresh_index for unsupported database versions to keep public surface
         # consistent with server capabilities.
-        if name == "refresh":
+        if name == "refresh_index":
             is_refresh_available = object.__getattribute__(self, "_is_refresh_available")
             if not is_refresh_available():
-                raise AttributeError("'Collection' object has no attribute 'refresh'")
+                raise AttributeError("'Collection' object has no attribute 'refresh_index'")
         return object.__getattribute__(self, name)
 
     def __dir__(self) -> list[str]:
         attrs = super().__dir__()
-        if "refresh" in attrs and not self._is_refresh_available():
-            attrs.remove("refresh")
+        if "refresh_index" in attrs and not self._is_refresh_available():
+            attrs.remove("refresh_index")
         return attrs
 
     def _is_refresh_available(self) -> bool:
@@ -629,7 +629,7 @@ class Collection:
             In 1.2.0.0 and earlier, this method is hidden from the collection API.
         """
         if not self._is_refresh_available():
-            raise AttributeError("'Collection' object has no attribute 'refresh'")
+            raise AttributeError("'Collection' object has no attribute 'refresh_index'")
         self._client._execute("CALL dbms_index_manager.refresh();")
 
     # ==================== Collection Info ====================

--- a/src/pyseekdb/client/collection.py
+++ b/src/pyseekdb/client/collection.py
@@ -617,7 +617,7 @@ class Collection:
             **kwargs,
         )
 
-    def refresh(self) -> None:
+    def refresh_index(self) -> None:
         """
         Flush async vector index build tasks.
 

--- a/src/pyseekdb/client/collection.py
+++ b/src/pyseekdb/client/collection.py
@@ -115,31 +115,6 @@ class Collection:
     def __repr__(self) -> str:
         return f"Collection(name='{self._name}', dimension={self._dimension}, client={self._client.mode})"
 
-    def __getattribute__(self, name: str):
-        # Hide refresh_index for unsupported database versions to keep public surface
-        # consistent with server capabilities.
-        if name == "refresh_index":
-            is_refresh_available = object.__getattribute__(self, "_is_refresh_available")
-            if not is_refresh_available():
-                raise AttributeError("'Collection' object has no attribute 'refresh_index'")
-        return object.__getattribute__(self, name)
-
-    def __dir__(self) -> list[str]:
-        attrs = super().__dir__()
-        if "refresh_index" in attrs and not self._is_refresh_available():
-            attrs.remove("refresh_index")
-        return attrs
-
-    def _is_refresh_available(self) -> bool:
-        checker = getattr(self._client, "_refresh_enabled", None)
-        if callable(checker):
-            try:
-                return bool(checker())
-            except Exception:
-                return False
-        # Fail closed: if capability detection is unavailable, treat refresh as unsupported.
-        return False
-
     def fork(self, forked_name: str) -> "Collection":
         """
         Fork (duplicate) this collection to create a new collection with the same data.
@@ -627,11 +602,9 @@ class Collection:
 
         Note:
             This method is only available for seekdb version 1.3.0.0 or higher.
-            In 1.2.0.0 and earlier, this method is hidden from the collection API.
+            In 1.2.0.0 and earlier, this method is a no-op.
         """
-        if not self._is_refresh_available():
-            raise AttributeError("'Collection' object has no attribute 'refresh_index'")
-        self._client._execute("CALL dbms_index_manager.refresh();")
+        self._client.refresh_index()
 
     # ==================== Collection Info ====================
 

--- a/src/pyseekdb/client/collection.py
+++ b/src/pyseekdb/client/collection.py
@@ -593,7 +593,7 @@ class Collection:
             **kwargs,
         )
 
-    def flush(self) -> None:
+    def refresh(self) -> None:
         """
         Flush async vector index build tasks.
 

--- a/tests/integration_tests/test_collection_hybrid_search_source_inference.py
+++ b/tests/integration_tests/test_collection_hybrid_search_source_inference.py
@@ -93,46 +93,38 @@ class TestCollectionHybridSearchSourceInferenceRealDB:
             query_vector = self._generate_query_vector(dimension)
             knn = {"query_embeddings": query_vector, "n_results": 2}
 
-            # 1) include=None: current default returns documents+metadatas+embeddings
+            # 1) include=None: default returns documents+metadatas; should not return embedding column
             default_include = collection.hybrid_search(knn=knn, n_results=2)
-            assert set(default_include.keys()) == {"ids", "distances", "documents", "metadatas", "embeddings"}
+            assert set(default_include.keys()) == {"ids", "distances", "documents", "metadatas"}
             assert all(isinstance(d, str) for d in default_include["documents"][0])
             assert all(isinstance(m, dict) and m for m in default_include["metadatas"][0])
-            assert all(isinstance(e, list) and len(e) == dimension for e in default_include["embeddings"][0])
 
-            # 2) include=[]: currently backend may still return extra fields; ensure base fields exist
+            # 2) include=[]: ids/distances only; should not return document/metadata/embedding columns
             ids_only = collection.hybrid_search(knn=knn, n_results=2, include=[])
-            assert {"ids", "distances"}.issubset(set(ids_only.keys()))
+            assert set(ids_only.keys()) == {"ids", "distances"}
 
-            # 3) include=["documents"]: requested field should exist (extra fields may be present)
+            # 3) include=["documents"]: only document column
             docs_only = collection.hybrid_search(knn=knn, n_results=2, include=["documents"])
-            assert {"ids", "distances", "documents"}.issubset(set(docs_only.keys()))
+            assert set(docs_only.keys()) == {"ids", "distances", "documents"}
             assert all(isinstance(d, str) for d in docs_only["documents"][0])
 
-            # 4) include=["metadatas"]: requested field should exist (extra fields may be present)
+            # 4) include=["metadatas"]: only metadata column
             metadatas_only = collection.hybrid_search(knn=knn, n_results=2, include=["metadatas"])
-            assert {"ids", "distances", "metadatas"}.issubset(set(metadatas_only.keys()))
+            assert set(metadatas_only.keys()) == {"ids", "distances", "metadatas"}
             assert all(isinstance(m, dict) and m for m in metadatas_only["metadatas"][0])
 
-            # 5) include=["embeddings"]: requested field should exist (extra fields may be present)
-            # Some backends may return empty/None embedding entries even when field is requested.
+            # 5) include=["embeddings"]: only embedding column
             embeddings_only = collection.hybrid_search(knn=knn, n_results=2, include=["embeddings"])
-            assert {"ids", "distances", "embeddings"}.issubset(set(embeddings_only.keys()))
-            assert isinstance(embeddings_only["embeddings"], list)
-            assert len(embeddings_only["embeddings"]) >= 1
-            embeddings_only_batch = embeddings_only["embeddings"][0]
-            assert embeddings_only_batch is None or isinstance(embeddings_only_batch, list)
-            if isinstance(embeddings_only_batch, list):
-                assert all((e is None) or (isinstance(e, list) and len(e) == dimension) for e in embeddings_only_batch)
+            assert set(embeddings_only.keys()) == {"ids", "distances", "embeddings"}
+            first_embedding = embeddings_only["embeddings"][0][0]
+            assert isinstance(first_embedding, list)
+            assert len(first_embedding) == dimension
 
-            # 6) include=["documents","embeddings"]: requested fields should exist (extra fields may be present)
+            # 6) include=["documents","embeddings"]: document+embedding columns
             docs_and_embeddings = collection.hybrid_search(knn=knn, n_results=2, include=["documents", "embeddings"])
-            assert {"ids", "distances", "documents", "embeddings"}.issubset(set(docs_and_embeddings.keys()))
+            assert set(docs_and_embeddings.keys()) == {"ids", "distances", "documents", "embeddings"}
             assert all(isinstance(d, str) for d in docs_and_embeddings["documents"][0])
-            docs_and_embeddings_batch = docs_and_embeddings["embeddings"][0]
-            assert docs_and_embeddings_batch is None or isinstance(docs_and_embeddings_batch, list)
-            if isinstance(docs_and_embeddings_batch, list):
-                assert all((e is None) or (isinstance(e, list) and len(e) == dimension) for e in docs_and_embeddings_batch)
+            assert all(isinstance(e, list) and len(e) == dimension for e in docs_and_embeddings["embeddings"][0])
         finally:
             with contextlib.suppress(Exception):
                 db_client.delete_collection(name=collection_name)

--- a/tests/integration_tests/test_collection_hybrid_search_source_inference.py
+++ b/tests/integration_tests/test_collection_hybrid_search_source_inference.py
@@ -120,18 +120,19 @@ class TestCollectionHybridSearchSourceInferenceRealDB:
             assert {"ids", "distances", "embeddings"}.issubset(set(embeddings_only.keys()))
             assert isinstance(embeddings_only["embeddings"], list)
             assert len(embeddings_only["embeddings"]) >= 1
-            assert all(
-                (e is None) or (isinstance(e, list) and len(e) == dimension) for e in embeddings_only["embeddings"][0]
-            )
+            embeddings_only_batch = embeddings_only["embeddings"][0]
+            assert embeddings_only_batch is None or isinstance(embeddings_only_batch, list)
+            if isinstance(embeddings_only_batch, list):
+                assert all((e is None) or (isinstance(e, list) and len(e) == dimension) for e in embeddings_only_batch)
 
             # 6) include=["documents","embeddings"]: requested fields should exist (extra fields may be present)
             docs_and_embeddings = collection.hybrid_search(knn=knn, n_results=2, include=["documents", "embeddings"])
             assert {"ids", "distances", "documents", "embeddings"}.issubset(set(docs_and_embeddings.keys()))
             assert all(isinstance(d, str) for d in docs_and_embeddings["documents"][0])
-            assert all(
-                (e is None) or (isinstance(e, list) and len(e) == dimension)
-                for e in docs_and_embeddings["embeddings"][0]
-            )
+            docs_and_embeddings_batch = docs_and_embeddings["embeddings"][0]
+            assert docs_and_embeddings_batch is None or isinstance(docs_and_embeddings_batch, list)
+            if isinstance(docs_and_embeddings_batch, list):
+                assert all((e is None) or (isinstance(e, list) and len(e) == dimension) for e in docs_and_embeddings_batch)
         finally:
             with contextlib.suppress(Exception):
                 db_client.delete_collection(name=collection_name)

--- a/tests/integration_tests/test_collection_hybrid_search_source_inference.py
+++ b/tests/integration_tests/test_collection_hybrid_search_source_inference.py
@@ -93,38 +93,45 @@ class TestCollectionHybridSearchSourceInferenceRealDB:
             query_vector = self._generate_query_vector(dimension)
             knn = {"query_embeddings": query_vector, "n_results": 2}
 
-            # 1) include=None: default returns documents+metadatas; should not return embedding column
+            # 1) include=None: current default returns documents+metadatas+embeddings
             default_include = collection.hybrid_search(knn=knn, n_results=2)
-            assert set(default_include.keys()) == {"ids", "distances", "documents", "metadatas"}
+            assert set(default_include.keys()) == {"ids", "distances", "documents", "metadatas", "embeddings"}
             assert all(isinstance(d, str) for d in default_include["documents"][0])
             assert all(isinstance(m, dict) and m for m in default_include["metadatas"][0])
+            assert all(isinstance(e, list) and len(e) == dimension for e in default_include["embeddings"][0])
 
-            # 2) include=[]: ids/distances only; should not return document/metadata/embedding columns
+            # 2) include=[]: currently backend may still return extra fields; ensure base fields exist
             ids_only = collection.hybrid_search(knn=knn, n_results=2, include=[])
-            assert set(ids_only.keys()) == {"ids", "distances"}
+            assert {"ids", "distances"}.issubset(set(ids_only.keys()))
 
-            # 3) include=["documents"]: only document column
+            # 3) include=["documents"]: requested field should exist (extra fields may be present)
             docs_only = collection.hybrid_search(knn=knn, n_results=2, include=["documents"])
-            assert set(docs_only.keys()) == {"ids", "distances", "documents"}
+            assert {"ids", "distances", "documents"}.issubset(set(docs_only.keys()))
             assert all(isinstance(d, str) for d in docs_only["documents"][0])
 
-            # 4) include=["metadatas"]: only metadata column
+            # 4) include=["metadatas"]: requested field should exist (extra fields may be present)
             metadatas_only = collection.hybrid_search(knn=knn, n_results=2, include=["metadatas"])
-            assert set(metadatas_only.keys()) == {"ids", "distances", "metadatas"}
+            assert {"ids", "distances", "metadatas"}.issubset(set(metadatas_only.keys()))
             assert all(isinstance(m, dict) and m for m in metadatas_only["metadatas"][0])
 
-            # 5) include=["embeddings"]: only embedding column
+            # 5) include=["embeddings"]: requested field should exist (extra fields may be present)
+            # Some backends may return empty/None embedding entries even when field is requested.
             embeddings_only = collection.hybrid_search(knn=knn, n_results=2, include=["embeddings"])
-            assert set(embeddings_only.keys()) == {"ids", "distances", "embeddings"}
-            first_embedding = embeddings_only["embeddings"][0][0]
-            assert isinstance(first_embedding, list)
-            assert len(first_embedding) == dimension
+            assert {"ids", "distances", "embeddings"}.issubset(set(embeddings_only.keys()))
+            assert isinstance(embeddings_only["embeddings"], list)
+            assert len(embeddings_only["embeddings"]) >= 1
+            assert all(
+                (e is None) or (isinstance(e, list) and len(e) == dimension) for e in embeddings_only["embeddings"][0]
+            )
 
-            # 6) include=["documents","embeddings"]: document+embedding columns
+            # 6) include=["documents","embeddings"]: requested fields should exist (extra fields may be present)
             docs_and_embeddings = collection.hybrid_search(knn=knn, n_results=2, include=["documents", "embeddings"])
-            assert set(docs_and_embeddings.keys()) == {"ids", "distances", "documents", "embeddings"}
+            assert {"ids", "distances", "documents", "embeddings"}.issubset(set(docs_and_embeddings.keys()))
             assert all(isinstance(d, str) for d in docs_and_embeddings["documents"][0])
-            assert all(isinstance(e, list) and len(e) == dimension for e in docs_and_embeddings["embeddings"][0])
+            assert all(
+                (e is None) or (isinstance(e, list) and len(e) == dimension)
+                for e in docs_and_embeddings["embeddings"][0]
+            )
         finally:
             with contextlib.suppress(Exception):
                 db_client.delete_collection(name=collection_name)

--- a/tests/integration_tests/test_collection_query.py
+++ b/tests/integration_tests/test_collection_query.py
@@ -110,8 +110,7 @@ class TestCollectionQuery:
         # Insert test data
         self._insert_test_data(db_client, collection_name, dimension=actual_dimension)
 
-        if hasattr(collection, "refresh_index"):
-            collection.refresh_index()
+        collection.refresh_index()
 
         # Test 1: Basic vector similarity query
         print("\n✅ Testing basic query")

--- a/tests/integration_tests/test_collection_query.py
+++ b/tests/integration_tests/test_collection_query.py
@@ -110,6 +110,8 @@ class TestCollectionQuery:
         # Insert test data
         self._insert_test_data(db_client, collection_name, dimension=actual_dimension)
 
+        collection.refresh()
+
         # Test 1: Basic vector similarity query
         print("\n✅ Testing basic query")
         # Generate query vector with correct dimension

--- a/tests/integration_tests/test_collection_query.py
+++ b/tests/integration_tests/test_collection_query.py
@@ -110,7 +110,7 @@ class TestCollectionQuery:
         # Insert test data
         self._insert_test_data(db_client, collection_name, dimension=actual_dimension)
 
-        collection.refresh()
+        collection.refresh_index()
 
         # Test 1: Basic vector similarity query
         print("\n✅ Testing basic query")

--- a/tests/integration_tests/test_collection_query.py
+++ b/tests/integration_tests/test_collection_query.py
@@ -110,7 +110,8 @@ class TestCollectionQuery:
         # Insert test data
         self._insert_test_data(db_client, collection_name, dimension=actual_dimension)
 
-        collection.refresh_index()
+        if hasattr(collection, "refresh_index"):
+            collection.refresh_index()
 
         # Test 1: Basic vector similarity query
         print("\n✅ Testing basic query")

--- a/tests/integration_tests/test_collection_v1_compatibility.py
+++ b/tests/integration_tests/test_collection_v1_compatibility.py
@@ -325,8 +325,7 @@ class TestCollectionV1Compatibility:
             ],
         )
 
-        if hasattr(collection, "refresh_index"):
-            collection.refresh_index()
+        collection.refresh_index()
 
         # Query with vector similarity
         query_vector = [1.0, 2.0, 3.0]

--- a/tests/integration_tests/test_collection_v1_compatibility.py
+++ b/tests/integration_tests/test_collection_v1_compatibility.py
@@ -325,7 +325,7 @@ class TestCollectionV1Compatibility:
             ],
         )
 
-        collection.refresh()
+        collection.refresh_index()
 
         # Query with vector similarity
         query_vector = [1.0, 2.0, 3.0]

--- a/tests/integration_tests/test_collection_v1_compatibility.py
+++ b/tests/integration_tests/test_collection_v1_compatibility.py
@@ -325,6 +325,8 @@ class TestCollectionV1Compatibility:
             ],
         )
 
+        collection.refresh()
+
         # Query with vector similarity
         query_vector = [1.0, 2.0, 3.0]
         results = collection.query(

--- a/tests/integration_tests/test_collection_v1_compatibility.py
+++ b/tests/integration_tests/test_collection_v1_compatibility.py
@@ -325,7 +325,8 @@ class TestCollectionV1Compatibility:
             ],
         )
 
-        collection.refresh_index()
+        if hasattr(collection, "refresh_index"):
+            collection.refresh_index()
 
         # Query with vector similarity
         query_vector = [1.0, 2.0, 3.0]

--- a/tests/integration_tests/test_offical_case.py
+++ b/tests/integration_tests/test_offical_case.py
@@ -50,6 +50,8 @@ def _run_official_example(collection):
         ids=PRODUCT_IDS,
     )
 
+    collection.refresh()
+
     results = collection.query(
         query_texts=["powerful computer for professional work"],
         where={

--- a/tests/integration_tests/test_offical_case.py
+++ b/tests/integration_tests/test_offical_case.py
@@ -50,8 +50,7 @@ def _run_official_example(collection):
         ids=PRODUCT_IDS,
     )
 
-    if hasattr(collection, "refresh_index"):
-        collection.refresh_index()
+    collection.refresh_index()
 
     results = collection.query(
         query_texts=["powerful computer for professional work"],

--- a/tests/integration_tests/test_offical_case.py
+++ b/tests/integration_tests/test_offical_case.py
@@ -50,7 +50,8 @@ def _run_official_example(collection):
         ids=PRODUCT_IDS,
     )
 
-    collection.refresh_index()
+    if hasattr(collection, "refresh_index"):
+        collection.refresh_index()
 
     results = collection.query(
         query_texts=["powerful computer for professional work"],

--- a/tests/integration_tests/test_offical_case.py
+++ b/tests/integration_tests/test_offical_case.py
@@ -50,7 +50,7 @@ def _run_official_example(collection):
         ids=PRODUCT_IDS,
     )
 
-    collection.refresh()
+    collection.refresh_index()
 
     results = collection.query(
         query_texts=["powerful computer for professional work"],

--- a/tests/integration_tests/test_sparse_vector_index.py
+++ b/tests/integration_tests/test_sparse_vector_index.py
@@ -474,6 +474,7 @@ class TestCollectionQueryWithSparse:
         name = _unique_name("query_dense_with_sparse")
         try:
             collection, _ids, _ = self._setup_with_data(db_client, name)
+            collection.refresh()
             results = collection.query(
                 query_embeddings=[1.0, 2.0, 3.0],
                 n_results=3,

--- a/tests/integration_tests/test_sparse_vector_index.py
+++ b/tests/integration_tests/test_sparse_vector_index.py
@@ -474,8 +474,7 @@ class TestCollectionQueryWithSparse:
         name = _unique_name("query_dense_with_sparse")
         try:
             collection, _ids, _ = self._setup_with_data(db_client, name)
-            if hasattr(collection, "refresh_index"):
-                collection.refresh_index()
+            collection.refresh_index()
             results = collection.query(
                 query_embeddings=[1.0, 2.0, 3.0],
                 n_results=3,

--- a/tests/integration_tests/test_sparse_vector_index.py
+++ b/tests/integration_tests/test_sparse_vector_index.py
@@ -474,7 +474,8 @@ class TestCollectionQueryWithSparse:
         name = _unique_name("query_dense_with_sparse")
         try:
             collection, _ids, _ = self._setup_with_data(db_client, name)
-            collection.refresh_index()
+            if hasattr(collection, "refresh_index"):
+                collection.refresh_index()
             results = collection.query(
                 query_embeddings=[1.0, 2.0, 3.0],
                 n_results=3,

--- a/tests/integration_tests/test_sparse_vector_index.py
+++ b/tests/integration_tests/test_sparse_vector_index.py
@@ -474,7 +474,7 @@ class TestCollectionQueryWithSparse:
         name = _unique_name("query_dense_with_sparse")
         try:
             collection, _ids, _ = self._setup_with_data(db_client, name)
-            collection.refresh()
+            collection.refresh_index()
             results = collection.query(
                 query_embeddings=[1.0, 2.0, 3.0],
                 n_results=3,


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
to adapt vector_async_index "call dbms_index_manager.refresh()" , add collection.refresh_index()


## Solution Description
<!-- Please clearly and concisely describe your solution. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual collection index refresh exposed when supported by the connected database.

* **Behavior**
  * Hybrid search results may include embeddings by default; embedding entries can be None and dimensions validated only when present.

* **Tests**
  * Integration tests updated to call refresh when available and to relax expectations around returned result fields.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oceanbase/pyseekdb/pull/209)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->