### PR TITLE
calling refresh_index before query

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ collection.add(
     metadatas=[{"tag": "hello"}, {"tag": "demo"}],
 )
 
+# Refresh the index to make the added documents searchable
+collection.refresh_index()
+
 results = collection.query(query_texts=["hello"], n_results=3)
 print(results["ids"][0])
 ```

--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -247,6 +247,7 @@ collection.upsert(
 # ============================================================================
 
 # 6.1 Basic vector similarity query
+collection.refresh_index()  # Refresh index to ensure all updates are searchable
 query_vector = embeddings[0]  # Query with first document's vector
 results = collection.query(query_embeddings=query_vector, n_results=3)
 print(f"Query results: {len(results['ids'][0])} items")

--- a/examples/hybrid_search_example.py
+++ b/examples/hybrid_search_example.py
@@ -54,6 +54,8 @@ metadatas = [
 ids = [f"doc_{i + 1}" for i in range(len(documents))]
 collection.add(ids=ids, documents=documents, metadatas=metadatas)
 
+collection.refresh_index()  # Refresh index to ensure all updates are searchable
+
 print("=" * 100)
 print("SCENARIO 1: Keyword + Semantic Search")
 print("=" * 100)

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -82,6 +82,9 @@ collection.add(
 print(f"\nAdded {len(documents)} documents to collection")
 print("Note: Embeddings were automatically generated from documents using the embedding function")
 
+# Refresh the index to make the added documents searchable
+collection.refresh_index()
+
 # ==================== Step 4: Query the Collection ====================
 # With embedding function, you can query using text directly
 # The embedding function will automatically convert query text to query vector

--- a/examples/sparse_vector_index_example.py
+++ b/examples/sparse_vector_index_example.py
@@ -51,6 +51,8 @@ collection.add(
     ],
 )
 
+collection.refresh_index()  # Refresh index to ensure all updates are searchable
+
 # 5. Run sparse vector search
 results = collection.query(
     query_texts=["machine learning"],
@@ -245,6 +247,7 @@ docs = [
 ]
 ids = [str(i) for i in range(len(docs))]
 collection.add(documents=docs, ids=ids)
+collection.refresh_index()  # Refresh index to ensure all updates are searchable
 
 query = "apple fruit"
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
calling refresh_index before query.
Fix the examples which doesn't calling refresh_index() interface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README Quick Start guide and example scripts to include index refresh after document insertion
  * Ensures consistent demonstration of search workflows across all documentation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oceanbase/pyseekdb/pull/217)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->