### PR TITLE
docs: add SDK guide link to README Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Key features:
 ## Documentation
 
 - Docs home: https://docs.seekdb.ai
+- SDK guide: https://docs.seekdb.ai/seekdb/pyseekdb-sdk-get-started
 - User guide: https://docs.seekdb.ai/seekdb/deploy-overview
 - API reference: https://docs.seekdb.ai/seekdb/api-overview
 - RAG demo: [English](demo/rag/README.md) / [中文](demo/rag/README_CN.md)


### PR DESCRIPTION
## Summary
- Add SDK guide link (`https://docs.seekdb.ai/seekdb/pyseekdb-sdk-get-started`) to the Documentation section of README.md, placed as the second line after "Docs home"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a direct link to the Pyseekdb SDK get-started guide in the Documentation links section.
  * Makes SDK setup, installation, and usage guidance easier to find.
  * Improves onboarding and quick access to SDK reference materials for users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oceanbase/pyseekdb/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->