### PR TITLE
Fix empty hybrid_search results and refresh index in integration test

### DIFF
--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -3723,14 +3723,6 @@ class BaseClient(BaseConnection, AdminAPI):
             Standard format dictionary with ids, distances, metadatas, documents, embeddings
             in query-compatible format (List[List[...]] for consistency with query method)
         """
-        if not result_rows:
-            return {
-                "ids": [[]],
-                "distances": [[]],
-                "metadatas": [[]],
-                "documents": [[]],
-                "embeddings": [[]],
-            }
 
         ids = []
         distances = []

--- a/tests/integration_tests/test_collection_hybrid_search_source_inference.py
+++ b/tests/integration_tests/test_collection_hybrid_search_source_inference.py
@@ -93,6 +93,8 @@ class TestCollectionHybridSearchSourceInferenceRealDB:
             query_vector = self._generate_query_vector(dimension)
             knn = {"query_embeddings": query_vector, "n_results": 2}
 
+            collection.refresh_index()
+
             # 1) include=None: default returns documents+metadatas; should not return embedding column
             default_include = collection.hybrid_search(knn=knn, n_results=2)
             assert set(default_include.keys()) == {"ids", "distances", "documents", "metadatas"}

--- a/tests/unit_tests/test_hybrid_search_source_inference.py
+++ b/tests/unit_tests/test_hybrid_search_source_inference.py
@@ -26,6 +26,9 @@ class _DummyClient:
     def _build_source_fields(self, include: list[str] | None) -> list[str]:
         return BaseClient._build_source_fields(self, include)
 
+    def _convert_id_from_bytes(self, value: Any) -> Any:
+        return value
+
 
 class TestHybridSearchPublicSurfaceUnit:
     def test_collection_forwards_include_only(self) -> None:
@@ -87,3 +90,26 @@ class TestBuildSourceFieldsUnit:
         assert BaseClient._build_source_fields(dummy, include=["ids"]) == ["_id"]
         assert BaseClient._build_source_fields(dummy, include=["distances"]) == ["_id"]
         assert BaseClient._build_source_fields(dummy, include=["documents", "ids", "distances"]) == ["_id", "document"]
+
+
+class TestTransformSqlResultEmptyRowsUnit:
+    def test_empty_rows_returns_expected_columns_by_include(self) -> None:
+        dummy = _DummyClient()
+
+        default_result = BaseClient._transform_sql_result(dummy, result_rows=[], include=None)
+        assert set(default_result.keys()) == {"ids", "distances", "documents", "metadatas"}
+        assert default_result["ids"] == [[]]
+        assert default_result["distances"] == [[]]
+        assert default_result["documents"] == [[]]
+        assert default_result["metadatas"] == [[]]
+
+        ids_only_result = BaseClient._transform_sql_result(dummy, result_rows=[], include=[])
+        assert set(ids_only_result.keys()) == {"ids", "distances"}
+        assert ids_only_result["ids"] == [[]]
+        assert ids_only_result["distances"] == [[]]
+
+        embeddings_result = BaseClient._transform_sql_result(dummy, result_rows=[], include=["embeddings"])
+        assert set(embeddings_result.keys()) == {"ids", "distances", "embeddings"}
+        assert embeddings_result["ids"] == [[]]
+        assert embeddings_result["distances"] == [[]]
+        assert embeddings_result["embeddings"] == [[]]


### PR DESCRIPTION
## Summary

- Remove the early return in `_transform_sql_result` for empty `result_rows`, so empty hybrid/search results respect the `include` parameter instead of always returning all columns.
- Add unit tests covering empty-result shape for `include=None`, `include=[]`, and `include=["embeddings"]`.
- Call `collection.refresh_index()` before hybrid search in the integration test so index state is ready after recent `refresh_index`-before-query behavior (#217).

## Test plan

- [x] `uv run pytest tests/unit_tests/test_hybrid_search_source_inference.py`
- [ ] `uv run pytest tests/integration_tests/test_collection_hybrid_search_source_inference.py` (requires real DB)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty search results to return consistent column structures based on the requested data types.

* **Tests**
  * Added test coverage for empty result scenarios to verify correct column structure across various configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oceanbase/pyseekdb/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->