### PR TITLE
Fix concurrent get_or_create_collection races in embedded mode

### DIFF
--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -74,15 +74,15 @@ def _extract_collection_id_from_sdk_row(row: Any) -> str:
 
 
 def _is_collection_conflict_error(exc: BaseException) -> bool:
-    message = str(exc).lower()
-    if isinstance(exc, ValueError):
-        if "already exists" in message and "collection" in message:
+    current: BaseException | None = exc
+    while current is not None:
+        message = str(current).lower()
+        if "already exists" in message and ("collection" in message or "table" in message or "code=1050" in message):
             return True
-        if "failed to create collection metadata" in message:
+        if type(current).__name__ == "SeekdbError" and "already exists" in message:
             return True
-    if "already exists" in message and ("table" in message or "code=1050" in message):
-        return True
-    return type(exc).__name__ == "SeekdbError" and "already exists" in message
+        current = current.__cause__
+    return False
 
 
 def _extract_hnsw_config(config: ConfigurationParam) -> HNSWConfiguration | None:

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -3,8 +3,10 @@ Base client interface definition
 """
 
 import contextlib
+import fcntl
 import json
 import logging
+import os
 import re
 import struct
 import warnings
@@ -61,6 +63,28 @@ _MAX_COLLECTION_NAME_LENGTH = 512
 logger = logging.getLogger(__name__)
 
 from .types import _NOT_PROVIDED, _NotProvided  # noqa: E402, F401
+
+
+def _extract_collection_id_from_sdk_row(row: Any) -> str:
+    if isinstance(row, dict):
+        collection_id = row.get("COLLECTION_ID", "")
+    elif isinstance(row, (tuple, list)):
+        collection_id = row[0] if len(row) > 0 else ""
+    else:
+        collection_id = str(row)
+    return str(collection_id or "")
+
+
+def _is_collection_conflict_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    if isinstance(exc, ValueError):
+        if "already exists" in message and "collection" in message:
+            return True
+        if "failed to create collection metadata" in message:
+            return True
+    if "already exists" in message and ("table" in message or "code=1050" in message):
+        return True
+    return type(exc).__name__ == "SeekdbError" and "already exists" in message
 
 
 def _extract_hnsw_config(config: ConfigurationParam) -> HNSWConfiguration | None:
@@ -715,7 +739,23 @@ class BaseClient(BaseConnection, AdminAPI):
             fulltext_index=fulltext_config,
         )
 
-    def create_collection(
+    @contextlib.contextmanager
+    def _collection_creation_lock(self):
+        """Serialize collection creation for embedded clients across processes."""
+        db_path = getattr(self, "path", None)
+        if not db_path:
+            yield
+            return
+
+        lock_path = os.path.join(db_path, ".pyseekdb.collection.lock")
+        with open(lock_path, "w", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    def create_collection(  # noqa: C901
         self,
         name: str,
         schema: Schema | None = None,
@@ -843,7 +883,12 @@ class BaseClient(BaseConnection, AdminAPI):
 
         # Execute SQL to create table
         logger.debug(f"Creating table: {table_name} with SQL: {sql}")
-        self._execute(sql)
+        try:
+            self._execute(sql)
+        except Exception as exc:
+            if _is_collection_conflict_error(exc):
+                raise ValueError(f"Collection '{name}' already exists") from exc
+            raise
 
         # Create and return Collection object
         return Collection(
@@ -928,11 +973,16 @@ class BaseClient(BaseConnection, AdminAPI):
 
             self._create_sdk_collections_if_not_exists()
             collection_name_in_table = escape_string(collection_name)
-            delete_sql = f"DELETE FROM `{CollectionNames.sdk_collections_table_name()}` WHERE COLLECTION_NAME = '{collection_name_in_table}'"
-            self._execute(delete_sql)
-            insert_sql = f"INSERT INTO `{CollectionNames.sdk_collections_table_name()}` (COLLECTION_NAME, SETTINGS) VALUES ('{collection_name_in_table}', '{settings_str}')"
-            self._execute(insert_sql)
-            collection_id = self._get_collection_id(collection_name)
+            try:
+                collection_id = self._get_collection_id(collection_name)
+            except ValueError:
+                insert_sql = (
+                    f"INSERT INTO `{CollectionNames.sdk_collections_table_name()}` "
+                    f"(COLLECTION_NAME, SETTINGS) VALUES ('{collection_name_in_table}', '{settings_str}')"
+                )
+                self._execute(insert_sql)
+                collection_id = self._get_collection_id(collection_name)
+
             results["collection_id"] = collection_id
             results["table_name"] = CollectionNames.table_name_v2(collection_id)
             return results  # noqa: TRY300
@@ -1398,15 +1448,9 @@ class BaseClient(BaseConnection, AdminAPI):
             rows = self._execute(query_sql)
             if not rows or len(rows) == 0:
                 return False
-            if isinstance(rows[0], dict):
-                collection_id = rows[0]["COLLECTION_ID"]
-            elif isinstance(rows[0], (tuple, list)):
-                collection_id = rows[0][0] if len(rows[0]) > 0 else ""
-            else:
-                collection_id = str(rows[0])
-            desc_sql = f"DESCRIBE `{CollectionNames.table_name_v2(collection_id)}`"
-            desc_result = self._execute(desc_sql)
-            return not (not desc_result or len(desc_result) == 0)
+
+            collection_id = _extract_collection_id_from_sdk_row(rows[0])
+            return bool(collection_id)
         except Exception:
             return False
 
@@ -1469,20 +1513,22 @@ class BaseClient(BaseConnection, AdminAPI):
         # Validate collection name before any database interaction
         _validate_collection_name(name)
 
-        # First, try to get the collection
-        if self.has_collection(name):
-            # Collection exists, return it
-            # Pass embedding_function (could be _NOT_PROVIDED, None, or an EmbeddingFunction instance)
-            return self.get_collection(name, embedding_function=embedding_function)
+        with self._collection_creation_lock():
+            if self.has_collection(name):
+                return self.get_collection(name, embedding_function=embedding_function)
 
-        # Collection doesn't exist, create it with provided or default configuration
-        return self.create_collection(
-            name=name,
-            schema=schema,
-            configuration=configuration,
-            embedding_function=embedding_function,
-            **kwargs,
-        )
+            try:
+                return self.create_collection(
+                    name=name,
+                    schema=schema,
+                    configuration=configuration,
+                    embedding_function=embedding_function,
+                    **kwargs,
+                )
+            except Exception as exc:
+                if _is_collection_conflict_error(exc) or self.has_collection(name):
+                    return self.get_collection(name, embedding_function=embedding_function)
+                raise
 
     def _get_collection_table_name(self, collection_id: str | None, collection_name: str) -> str:
         """
@@ -1527,12 +1573,9 @@ class BaseClient(BaseConnection, AdminAPI):
         collection_id_query_result = self._execute(collection_id_query_sql)
         if not collection_id_query_result or len(collection_id_query_result) == 0:
             raise ValueError(f"Collection not found: '{collection_name}'")
-        if isinstance(collection_id_query_result[0], dict):
-            collection_id = collection_id_query_result[0]["COLLECTION_ID"]
-        elif isinstance(collection_id_query_result[0], (tuple, list)):
-            collection_id = collection_id_query_result[0][0] if len(collection_id_query_result[0]) > 0 else ""
-        else:
-            collection_id = str(collection_id_query_result[0])
+        collection_id = _extract_collection_id_from_sdk_row(collection_id_query_result[0])
+        if not collection_id:
+            raise ValueError(f"Collection not found: '{collection_name}'")
         return collection_id
 
     def _collection_fork(self, collection: Collection, forked_name: str) -> None:

--- a/src/pyseekdb/client/client_base.py
+++ b/src/pyseekdb/client/client_base.py
@@ -3,10 +3,8 @@ Base client interface definition
 """
 
 import contextlib
-import fcntl
 import json
 import logging
-import os
 import re
 import struct
 import warnings
@@ -739,23 +737,7 @@ class BaseClient(BaseConnection, AdminAPI):
             fulltext_index=fulltext_config,
         )
 
-    @contextlib.contextmanager
-    def _collection_creation_lock(self):
-        """Serialize collection creation for embedded clients across processes."""
-        db_path = getattr(self, "path", None)
-        if not db_path:
-            yield
-            return
-
-        lock_path = os.path.join(db_path, ".pyseekdb.collection.lock")
-        with open(lock_path, "w", encoding="utf-8") as lock_file:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-
-    def create_collection(  # noqa: C901
+    def create_collection(
         self,
         name: str,
         schema: Schema | None = None,
@@ -808,6 +790,8 @@ class BaseClient(BaseConnection, AdminAPI):
             ... )
         """
         _validate_collection_name(name)
+        # Only fully initialized collections (metadata + physical table) count as existing.
+        # Metadata without a table is treated as an incomplete create and repaired below.
         if self.has_collection(name):
             raise ValueError(f"Collection '{name}' already exists")
 
@@ -872,7 +856,7 @@ class BaseClient(BaseConnection, AdminAPI):
             table_name = collection_meta["table_name"]
 
         # Construct CREATE TABLE SQL statement with HEAP organization
-        sql = f"""CREATE TABLE `{table_name}` (
+        sql = f"""CREATE TABLE IF NOT EXISTS `{table_name}` (
             _id varbinary(512) PRIMARY KEY NOT NULL,
             document string,
             embedding vector({dimension}),
@@ -883,12 +867,7 @@ class BaseClient(BaseConnection, AdminAPI):
 
         # Execute SQL to create table
         logger.debug(f"Creating table: {table_name} with SQL: {sql}")
-        try:
-            self._execute(sql)
-        except Exception as exc:
-            if _is_collection_conflict_error(exc):
-                raise ValueError(f"Collection '{name}' already exists") from exc
-            raise
+        self._execute(sql)
 
         # Create and return Collection object
         return Collection(
@@ -1442,6 +1421,13 @@ class BaseClient(BaseConnection, AdminAPI):
         """
         return self._has_collection_v2(name) or self._has_collection_v1(name)
 
+    def _collection_table_exists(self, table_name: str) -> bool:
+        try:
+            table_info = self._execute(f"DESCRIBE `{table_name}`")
+            return table_info is not None and len(table_info) > 0
+        except Exception:
+            return False
+
     def _has_collection_v2(self, name: str) -> bool:
         try:
             query_sql = f"SELECT COLLECTION_ID FROM {CollectionNames.sdk_collections_table_name()} WHERE COLLECTION_NAME = '{name}'"
@@ -1450,7 +1436,10 @@ class BaseClient(BaseConnection, AdminAPI):
                 return False
 
             collection_id = _extract_collection_id_from_sdk_row(rows[0])
-            return bool(collection_id)
+            if not collection_id:
+                return False
+
+            return self._collection_table_exists(CollectionNames.table_name_v2(collection_id))
         except Exception:
             return False
 
@@ -1513,22 +1502,21 @@ class BaseClient(BaseConnection, AdminAPI):
         # Validate collection name before any database interaction
         _validate_collection_name(name)
 
-        with self._collection_creation_lock():
-            if self.has_collection(name):
-                return self.get_collection(name, embedding_function=embedding_function)
+        if self.has_collection(name):
+            return self.get_collection(name, embedding_function=embedding_function)
 
-            try:
-                return self.create_collection(
-                    name=name,
-                    schema=schema,
-                    configuration=configuration,
-                    embedding_function=embedding_function,
-                    **kwargs,
-                )
-            except Exception as exc:
-                if _is_collection_conflict_error(exc) or self.has_collection(name):
-                    return self.get_collection(name, embedding_function=embedding_function)
-                raise
+        try:
+            return self.create_collection(
+                name=name,
+                schema=schema,
+                configuration=configuration,
+                embedding_function=embedding_function,
+                **kwargs,
+            )
+        except Exception as exc:
+            if _is_collection_conflict_error(exc) or self.has_collection(name):
+                return self.get_collection(name, embedding_function=embedding_function)
+            raise
 
     def _get_collection_table_name(self, collection_id: str | None, collection_name: str) -> str:
         """

--- a/tests/integration_tests/test_get_or_create_collection_multiprocess.py
+++ b/tests/integration_tests/test_get_or_create_collection_multiprocess.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import gc
 import importlib
+import importlib.metadata
 import multiprocessing as mp
 import sys
 import tempfile
@@ -22,6 +23,7 @@ from queue import Empty
 from typing import Any
 
 import pytest
+from packaging.version import Version
 
 repo_root = Path(__file__).resolve().parents[2]
 src_root = repo_root / "src"
@@ -32,6 +34,7 @@ NUM_PROCESSES = 2
 THREADS_PER_PROCESS = 3
 ITEMS_PER_THREAD = 5
 WORKER_TIMEOUT_SECONDS = 60
+MIN_PYLIBSEEKDB_VERSION = Version("1.3.0.post1")
 
 
 def _purge_pyseekdb_modules() -> None:
@@ -66,6 +69,23 @@ def _refresh_collection(db_path: str, database: str, collection_name: str) -> No
     client = _make_client(db_path, database)
     collection = _get_collection(client, collection_name)
     collection.refresh_index()
+
+
+def _require_embedded_pylibseekdb() -> None:
+    try:
+        import pylibseekdb  # noqa: F401
+    except ImportError:
+        pytest.skip("seekdb embedded package is not installed")
+
+    try:
+        installed_version = Version(importlib.metadata.version("pylibseekdb"))
+    except importlib.metadata.PackageNotFoundError:
+        pytest.skip("pylibseekdb is not installed")
+
+    if installed_version <= MIN_PYLIBSEEKDB_VERSION:
+        pytest.skip(
+            f"embedded multiprocess tests require pylibseekdb > {MIN_PYLIBSEEKDB_VERSION}, got {installed_version}"
+        )
 
 
 def _run_processes(
@@ -370,10 +390,7 @@ def _mixed_crud_worker(
 
 @pytest.fixture
 def embedded_multiprocess_db():
-    try:
-        import pylibseekdb  # noqa: F401
-    except ImportError:
-        pytest.skip("seekdb embedded package is not installed")
+    _require_embedded_pylibseekdb()
 
     db_path = Path(tempfile.mkdtemp(prefix="seekdb-mp-"))
     database = "test_mp"

--- a/tests/integration_tests/test_get_or_create_collection_multiprocess.py
+++ b/tests/integration_tests/test_get_or_create_collection_multiprocess.py
@@ -82,9 +82,9 @@ def _require_embedded_pylibseekdb() -> None:
     except importlib.metadata.PackageNotFoundError:
         pytest.skip("pylibseekdb is not installed")
 
-    if installed_version <= MIN_PYLIBSEEKDB_VERSION:
+    if installed_version < MIN_PYLIBSEEKDB_VERSION:
         pytest.skip(
-            f"embedded multiprocess tests require pylibseekdb > {MIN_PYLIBSEEKDB_VERSION}, got {installed_version}"
+            f"embedded multiprocess tests require pylibseekdb >= {MIN_PYLIBSEEKDB_VERSION}, got {installed_version}"
         )
 
 

--- a/tests/integration_tests/test_get_or_create_collection_multiprocess.py
+++ b/tests/integration_tests/test_get_or_create_collection_multiprocess.py
@@ -12,6 +12,7 @@ import gc
 import importlib
 import importlib.metadata
 import multiprocessing as mp
+import shutil
 import sys
 import tempfile
 import time
@@ -107,7 +108,7 @@ def _run_processes(
     for process in processes:
         if process.is_alive():
             process.terminate()
-            process.join(timeout=2)
+        process.join(timeout=2)
 
     results: list[dict[str, Any]] = []
     while len(results) < expected_count:
@@ -263,6 +264,8 @@ def _update_worker(
         ]
         collection.update(ids=ids, metadatas=metadatas)
         result = collection.get(ids=ids, include=["metadatas"])
+        if len(result["ids"]) != len(ids):
+            raise AssertionError(f"expected {len(ids)} updated rows, got {len(result['ids'])}")
         for metadata in result["metadatas"]:
             if not metadata.get("updated"):
                 raise AssertionError(f"metadata not updated: {metadata}")
@@ -402,6 +405,9 @@ def embedded_multiprocess_db():
     gc.collect()
 
     yield str(db_path), database
+
+    with contextlib.suppress(Exception):
+        shutil.rmtree(db_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/integration_tests/test_get_or_create_collection_multiprocess.py
+++ b/tests/integration_tests/test_get_or_create_collection_multiprocess.py
@@ -1,0 +1,597 @@
+"""
+Integration tests for concurrent collection operations in embedded mode.
+
+Covers multiprocess + multithread workloads. Each thread must use its own
+``pyseekdb.Client`` instance because ``Client`` is not thread-safe.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import gc
+import importlib
+import multiprocessing as mp
+import sys
+import tempfile
+import time
+import uuid
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from queue import Empty
+from typing import Any
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[2]
+src_root = repo_root / "src"
+sys.path.insert(0, str(src_root))
+
+EMBED_DIM = 8
+NUM_PROCESSES = 2
+THREADS_PER_PROCESS = 3
+ITEMS_PER_THREAD = 5
+WORKER_TIMEOUT_SECONDS = 60
+
+
+def _purge_pyseekdb_modules() -> None:
+    for module_name in list(sys.modules):
+        if module_name == "pyseekdb" or module_name.startswith("pyseekdb."):
+            del sys.modules[module_name]
+
+
+def _build_embedding(seed: int, embed_dim: int = EMBED_DIM) -> list[float]:
+    base = float(seed + 1)
+    return [((base + i) % 13) / 13.0 for i in range(embed_dim)]
+
+
+def _record_id(process_id: int, thread_id: int, seq: int) -> str:
+    return f"p{process_id:02d}_t{thread_id:02d}_{seq:04d}"
+
+
+def _import_pyseekdb():
+    return importlib.import_module("pyseekdb")
+
+
+def _make_client(db_path: str, database: str):
+    pyseekdb = _import_pyseekdb()
+    return pyseekdb.Client(path=db_path, database=database)
+
+
+def _get_collection(client, collection_name: str):
+    return client.get_collection(collection_name, embedding_function=None)
+
+
+def _refresh_collection(db_path: str, database: str, collection_name: str) -> None:
+    client = _make_client(db_path, database)
+    collection = _get_collection(client, collection_name)
+    collection.refresh_index()
+
+
+def _run_processes(
+    target: Callable[..., None],
+    args_list: list[tuple[Any, ...]],
+    expected_count: int,
+    timeout: float = WORKER_TIMEOUT_SECONDS,
+) -> list[dict[str, Any]]:
+    result_queue: mp.Queue[dict[str, Any]] = mp.Queue()
+    processes = [mp.Process(target=target, args=(*args, result_queue)) for args in args_list]
+
+    for process in processes:
+        process.start()
+
+    deadline = time.time() + timeout
+    while time.time() < deadline and any(process.is_alive() for process in processes):
+        time.sleep(0.1)
+
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=2)
+
+    results: list[dict[str, Any]] = []
+    while len(results) < expected_count:
+        try:
+            results.append(result_queue.get(timeout=0.5))
+        except Empty:
+            break
+
+    return results
+
+
+def _get_or_create_worker(
+    db_path: str,
+    database: str,
+    collection_name: str,
+    delay: float,
+    output: mp.Queue[dict[str, Any]],
+) -> None:
+    _purge_pyseekdb_modules()
+    time.sleep(delay)
+    try:
+        pyseekdb = _import_pyseekdb()
+        client = pyseekdb.Client(path=db_path, database=database)
+        collection = client.get_or_create_collection(
+            collection_name,
+            configuration=pyseekdb.HNSWConfiguration(dimension=EMBED_DIM, distance="cosine"),
+            embedding_function=None,
+        )
+        output.put({"ok": True, "name": collection.name})
+    except Exception as exc:
+        output.put({"ok": False, "error_type": type(exc).__name__, "error": str(exc)})
+
+
+def _add_worker(
+    db_path: str,
+    database: str,
+    collection_name: str,
+    process_id: int,
+    threads_per_process: int,
+    items_per_thread: int,
+    output: mp.Queue[dict[str, Any]],
+) -> None:
+    _purge_pyseekdb_modules()
+
+    def add_in_thread(thread_id: int) -> int:
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
+        embeddings = [_build_embedding(process_id * 10_000 + thread_id * 100 + seq) for seq in range(items_per_thread)]
+        documents = [f"insert p={process_id} t={thread_id} seq={seq}" for seq in range(items_per_thread)]
+        metadatas = [{"process_id": process_id, "thread_id": thread_id, "seq": seq} for seq in range(items_per_thread)]
+        collection.add(ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)
+        return len(ids)
+
+    try:
+        inserted = 0
+        with ThreadPoolExecutor(max_workers=threads_per_process) as executor:
+            futures = [executor.submit(add_in_thread, thread_id) for thread_id in range(threads_per_process)]
+            for future in as_completed(futures):
+                inserted += future.result()
+        output.put({"ok": True, "process_id": process_id, "inserted": inserted})
+    except Exception as exc:
+        output.put({"ok": False, "process_id": process_id, "error_type": type(exc).__name__, "error": str(exc)})
+
+
+def _get_worker(
+    db_path: str,
+    database: str,
+    collection_name: str,
+    process_id: int,
+    threads_per_process: int,
+    items_per_thread: int,
+    output: mp.Queue[dict[str, Any]],
+) -> None:
+    _purge_pyseekdb_modules()
+
+    def get_in_thread(thread_id: int) -> int:
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
+        result = collection.get(ids=ids, include=["documents", "metadatas"])
+        if len(result["ids"]) != len(ids):
+            raise AssertionError(f"expected {len(ids)} rows, got {len(result['ids'])}")
+        return len(result["ids"])
+
+    try:
+        fetched = 0
+        with ThreadPoolExecutor(max_workers=threads_per_process) as executor:
+            futures = [executor.submit(get_in_thread, thread_id) for thread_id in range(threads_per_process)]
+            for future in as_completed(futures):
+                fetched += future.result()
+        output.put({"ok": True, "process_id": process_id, "fetched": fetched})
+    except Exception as exc:
+        output.put({"ok": False, "process_id": process_id, "error_type": type(exc).__name__, "error": str(exc)})
+
+
+def _query_worker(
+    db_path: str,
+    database: str,
+    collection_name: str,
+    process_id: int,
+    threads_per_process: int,
+    queries_per_thread: int,
+    output: mp.Queue[dict[str, Any]],
+) -> None:
+    _purge_pyseekdb_modules()
+
+    def query_in_thread(thread_id: int) -> int:
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        completed = 0
+        for query_idx in range(queries_per_thread):
+            seed = process_id * 10_000 + thread_id * 100 + query_idx
+            result = collection.query(
+                query_embeddings=_build_embedding(seed),
+                n_results=3,
+                include=["documents", "metadatas"],
+            )
+            if not result["ids"] or not result["ids"][0]:
+                raise AssertionError("query returned empty result set")
+            completed += 1
+        return completed
+
+    try:
+        queried = 0
+        with ThreadPoolExecutor(max_workers=threads_per_process) as executor:
+            futures = [executor.submit(query_in_thread, thread_id) for thread_id in range(threads_per_process)]
+            for future in as_completed(futures):
+                queried += future.result()
+        output.put({"ok": True, "process_id": process_id, "queried": queried})
+    except Exception as exc:
+        output.put({"ok": False, "process_id": process_id, "error_type": type(exc).__name__, "error": str(exc)})
+
+
+def _update_worker(
+    db_path: str,
+    database: str,
+    collection_name: str,
+    process_id: int,
+    threads_per_process: int,
+    items_per_thread: int,
+    output: mp.Queue[dict[str, Any]],
+) -> None:
+    _purge_pyseekdb_modules()
+
+    def update_in_thread(thread_id: int) -> int:
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
+        metadatas = [
+            {"process_id": process_id, "thread_id": thread_id, "seq": seq, "updated": True}
+            for seq in range(items_per_thread)
+        ]
+        collection.update(ids=ids, metadatas=metadatas)
+        result = collection.get(ids=ids, include=["metadatas"])
+        for metadata in result["metadatas"]:
+            if not metadata.get("updated"):
+                raise AssertionError(f"metadata not updated: {metadata}")
+        return len(ids)
+
+    try:
+        updated = 0
+        with ThreadPoolExecutor(max_workers=threads_per_process) as executor:
+            futures = [executor.submit(update_in_thread, thread_id) for thread_id in range(threads_per_process)]
+            for future in as_completed(futures):
+                updated += future.result()
+        output.put({"ok": True, "process_id": process_id, "updated": updated})
+    except Exception as exc:
+        output.put({"ok": False, "process_id": process_id, "error_type": type(exc).__name__, "error": str(exc)})
+
+
+def _delete_worker(
+    db_path: str,
+    database: str,
+    collection_name: str,
+    process_id: int,
+    threads_per_process: int,
+    items_per_thread: int,
+    output: mp.Queue[dict[str, Any]],
+) -> None:
+    _purge_pyseekdb_modules()
+
+    def delete_in_thread(thread_id: int) -> int:
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
+        collection.delete(ids=ids)
+        result = collection.get(ids=ids, include=["documents"])
+        if result["ids"]:
+            raise AssertionError(f"expected deleted ids to be gone, still have {result['ids']}")
+        return len(ids)
+
+    try:
+        deleted = 0
+        with ThreadPoolExecutor(max_workers=threads_per_process) as executor:
+            futures = [executor.submit(delete_in_thread, thread_id) for thread_id in range(threads_per_process)]
+            for future in as_completed(futures):
+                deleted += future.result()
+        output.put({"ok": True, "process_id": process_id, "deleted": deleted})
+    except Exception as exc:
+        output.put({"ok": False, "process_id": process_id, "error_type": type(exc).__name__, "error": str(exc)})
+
+
+def _mixed_crud_worker(
+    db_path: str,
+    database: str,
+    collection_name: str,
+    process_id: int,
+    threads_per_process: int,
+    items_per_thread: int,
+    output: mp.Queue[dict[str, Any]],
+) -> None:
+    _purge_pyseekdb_modules()
+
+    def mixed_in_thread(thread_id: int) -> dict[str, int]:
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
+        embeddings = [_build_embedding(process_id * 10_000 + thread_id * 100 + seq) for seq in range(items_per_thread)]
+
+        collection.add(
+            ids=ids,
+            embeddings=embeddings,
+            documents=[f"mixed-add p={process_id} t={thread_id} seq={seq}" for seq in range(items_per_thread)],
+            metadatas=[
+                {"phase": "add", "process_id": process_id, "thread_id": thread_id, "seq": seq}
+                for seq in range(items_per_thread)
+            ],
+        )
+
+        get_result = collection.get(ids=ids, include=["documents"])
+        if len(get_result["ids"]) != len(ids):
+            raise AssertionError("mixed get after add failed")
+
+        collection.refresh_index()
+        query_result = collection.query(
+            query_embeddings=_build_embedding(process_id * 10_000 + thread_id * 100),
+            n_results=min(3, len(ids)),
+            include=["documents"],
+        )
+        if not query_result["ids"] or not query_result["ids"][0]:
+            raise AssertionError("mixed query after add failed")
+
+        collection.update(
+            ids=ids,
+            metadatas=[
+                {"phase": "update", "process_id": process_id, "thread_id": thread_id, "seq": seq}
+                for seq in range(items_per_thread)
+            ],
+        )
+
+        delete_ids = ids[: max(1, items_per_thread // 2)]
+        collection.delete(ids=delete_ids)
+        remaining = collection.get(ids=ids, include=["documents"])
+        remaining_ids = set(remaining["ids"])
+        for deleted_id in delete_ids:
+            if deleted_id in remaining_ids:
+                raise AssertionError(f"mixed delete left id behind: {deleted_id}")
+
+        return {
+            "added": len(ids),
+            "got": len(get_result["ids"]),
+            "queried": len(query_result["ids"][0]),
+            "updated": len(ids),
+            "deleted": len(delete_ids),
+        }
+
+    try:
+        totals = {"added": 0, "got": 0, "queried": 0, "updated": 0, "deleted": 0}
+        with ThreadPoolExecutor(max_workers=threads_per_process) as executor:
+            futures = [executor.submit(mixed_in_thread, thread_id) for thread_id in range(threads_per_process)]
+            for future in as_completed(futures):
+                thread_totals = future.result()
+                for key, value in thread_totals.items():
+                    totals[key] += value
+        output.put({"ok": True, "process_id": process_id, **totals})
+    except Exception as exc:
+        output.put({"ok": False, "process_id": process_id, "error_type": type(exc).__name__, "error": str(exc)})
+
+
+@pytest.fixture
+def embedded_multiprocess_db():
+    try:
+        import pylibseekdb  # noqa: F401
+    except ImportError:
+        pytest.skip("seekdb embedded package is not installed")
+
+    db_path = Path(tempfile.mkdtemp(prefix="seekdb-mp-"))
+    database = "test_mp"
+
+    pyseekdb = _import_pyseekdb()
+    admin = pyseekdb.AdminClient(path=str(db_path))
+    admin.create_database(database)
+    del admin
+    gc.collect()
+
+    yield str(db_path), database
+
+
+@pytest.fixture
+def crud_collection(embedded_multiprocess_db):
+    db_path, database = embedded_multiprocess_db
+    collection_name = f"mp_crud_{uuid.uuid4().hex}"
+
+    pyseekdb = _import_pyseekdb()
+    client = pyseekdb.Client(path=db_path, database=database)
+    client.create_collection(
+        name=collection_name,
+        configuration=pyseekdb.HNSWConfiguration(dimension=EMBED_DIM, distance="cosine"),
+        embedding_function=None,
+    )
+
+    yield db_path, database, collection_name
+
+    with contextlib.suppress(Exception):
+        client.delete_collection(collection_name)
+
+
+def _seed_collection_rows(
+    db_path: str,
+    database: str,
+    collection_name: str,
+    num_processes: int,
+    threads_per_process: int,
+    items_per_thread: int,
+) -> int:
+    pyseekdb = _import_pyseekdb()
+    client = pyseekdb.Client(path=db_path, database=database)
+    collection = _get_collection(client, collection_name)
+
+    ids: list[str] = []
+    embeddings: list[list[float]] = []
+    documents: list[str] = []
+    metadatas: list[dict[str, int]] = []
+
+    for process_id in range(num_processes):
+        for thread_id in range(threads_per_process):
+            for seq in range(items_per_thread):
+                ids.append(_record_id(process_id, thread_id, seq))
+                seed = process_id * 10_000 + thread_id * 100 + seq
+                embeddings.append(_build_embedding(seed))
+                documents.append(f"seed p={process_id} t={thread_id} seq={seq}")
+                metadatas.append({"process_id": process_id, "thread_id": thread_id, "seq": seq})
+
+    collection.add(ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)
+    _refresh_collection(db_path, database, collection_name)
+    return len(ids)
+
+
+class TestGetOrCreateCollectionMultiprocess:
+    def test_concurrent_get_or_create_collection(self, embedded_multiprocess_db):
+        db_path, database = embedded_multiprocess_db
+        collection_name = f"mp_collection_{uuid.uuid4().hex}"
+
+        results = _run_processes(
+            _get_or_create_worker,
+            [
+                (db_path, database, collection_name, 0.0),
+                (db_path, database, collection_name, 0.05),
+                (db_path, database, collection_name, 0.1),
+            ],
+            expected_count=3,
+        )
+
+        assert len(results) == 3
+        assert all(result["ok"] for result in results), results
+
+        client = _make_client(db_path, database)
+        try:
+            assert client.has_collection(collection_name)
+            collection = _get_collection(client, collection_name)
+            assert collection.name == collection_name
+        finally:
+            with contextlib.suppress(Exception):
+                client.delete_collection(collection_name)
+
+
+class TestMultiprocessMultithreadCrud:
+    def test_concurrent_add(self, crud_collection):
+        db_path, database, collection_name = crud_collection
+
+        results = _run_processes(
+            _add_worker,
+            [
+                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                for process_id in range(NUM_PROCESSES)
+            ],
+            expected_count=NUM_PROCESSES,
+        )
+
+        assert len(results) == NUM_PROCESSES
+        assert all(result["ok"] for result in results), results
+
+        expected_rows = NUM_PROCESSES * THREADS_PER_PROCESS * ITEMS_PER_THREAD
+        total_inserted = sum(result["inserted"] for result in results)
+        assert total_inserted == expected_rows
+
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        assert collection.count() == expected_rows
+
+    def test_concurrent_get(self, crud_collection):
+        db_path, database, collection_name = crud_collection
+        expected_rows = _seed_collection_rows(
+            db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
+        )
+
+        results = _run_processes(
+            _get_worker,
+            [
+                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                for process_id in range(NUM_PROCESSES)
+            ],
+            expected_count=NUM_PROCESSES,
+        )
+
+        assert len(results) == NUM_PROCESSES
+        assert all(result["ok"] for result in results), results
+        assert sum(result["fetched"] for result in results) == expected_rows
+
+    def test_concurrent_query(self, crud_collection):
+        db_path, database, collection_name = crud_collection
+        _seed_collection_rows(db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+
+        results = _run_processes(
+            _query_worker,
+            [
+                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                for process_id in range(NUM_PROCESSES)
+            ],
+            expected_count=NUM_PROCESSES,
+        )
+
+        assert len(results) == NUM_PROCESSES
+        assert all(result["ok"] for result in results), results
+        expected_queries = NUM_PROCESSES * THREADS_PER_PROCESS * ITEMS_PER_THREAD
+        assert sum(result["queried"] for result in results) == expected_queries
+
+    def test_concurrent_update(self, crud_collection):
+        db_path, database, collection_name = crud_collection
+        expected_rows = _seed_collection_rows(
+            db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
+        )
+
+        results = _run_processes(
+            _update_worker,
+            [
+                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                for process_id in range(NUM_PROCESSES)
+            ],
+            expected_count=NUM_PROCESSES,
+        )
+
+        assert len(results) == NUM_PROCESSES
+        assert all(result["ok"] for result in results), results
+        assert sum(result["updated"] for result in results) == expected_rows
+
+    def test_concurrent_delete(self, crud_collection):
+        db_path, database, collection_name = crud_collection
+        expected_rows = _seed_collection_rows(
+            db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
+        )
+
+        results = _run_processes(
+            _delete_worker,
+            [
+                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                for process_id in range(NUM_PROCESSES)
+            ],
+            expected_count=NUM_PROCESSES,
+        )
+
+        assert len(results) == NUM_PROCESSES
+        assert all(result["ok"] for result in results), results
+        assert sum(result["deleted"] for result in results) == expected_rows
+
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        assert collection.count() == 0
+
+    def test_concurrent_mixed_crud(self, crud_collection):
+        db_path, database, collection_name = crud_collection
+
+        results = _run_processes(
+            _mixed_crud_worker,
+            [
+                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                for process_id in range(NUM_PROCESSES)
+            ],
+            expected_count=NUM_PROCESSES,
+        )
+
+        assert len(results) == NUM_PROCESSES
+        assert all(result["ok"] for result in results), results
+
+        expected_added = NUM_PROCESSES * THREADS_PER_PROCESS * ITEMS_PER_THREAD
+        expected_deleted = NUM_PROCESSES * THREADS_PER_PROCESS * max(1, ITEMS_PER_THREAD // 2)
+        assert sum(result["added"] for result in results) == expected_added
+        assert sum(result["deleted"] for result in results) == expected_deleted
+
+        client = _make_client(db_path, database)
+        collection = _get_collection(client, collection_name)
+        assert collection.count() == expected_added - expected_deleted
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/integration_tests/test_get_or_create_collection_multiprocess.py
+++ b/tests/integration_tests/test_get_or_create_collection_multiprocess.py
@@ -1,8 +1,11 @@
 """
-Integration tests for concurrent collection operations in embedded mode.
+Integration tests for concurrent collection operations in embedded and OceanBase modes.
 
 Covers multiprocess + multithread workloads. Each thread must use its own
 ``pyseekdb.Client`` instance because ``Client`` is not thread-safe.
+
+These tests are tagged with ``[embedded]`` / ``[oceanbase]`` and run only in the
+corresponding integration-test CI jobs, not in the unit-test integration step.
 """
 
 from __future__ import annotations
@@ -12,6 +15,7 @@ import gc
 import importlib
 import importlib.metadata
 import multiprocessing as mp
+import os
 import shutil
 import sys
 import tempfile
@@ -38,7 +42,13 @@ WORKER_TIMEOUT_SECONDS = 60
 MIN_PYLIBSEEKDB_VERSION = Version("1.3.0.post1")
 _MP_CONTEXT = mp.get_context("spawn")
 
-pytestmark = pytest.mark.parametrize("_mode", ["embedded"], ids=["embedded"])
+OB_HOST = os.environ.get("OB_HOST", "localhost")
+OB_PORT = int(os.environ.get("OB_PORT", "11202"))
+OB_TENANT = os.environ.get("OB_TENANT", "mysql")
+OB_USER = os.environ.get("OB_USER", "root")
+OB_PASSWORD = os.environ.get("OB_PASSWORD", "")
+
+pytestmark = pytest.mark.parametrize("_mode", ["embedded", "oceanbase"], ids=["embedded", "oceanbase"])
 
 
 def _purge_pyseekdb_modules() -> None:
@@ -60,17 +70,45 @@ def _import_pyseekdb():
     return importlib.import_module("pyseekdb")
 
 
-def _make_client(db_path: str, database: str):
+def _make_client(client_config: dict[str, Any]):
     pyseekdb = _import_pyseekdb()
-    return pyseekdb.Client(path=db_path, database=database)
+    mode = client_config["mode"]
+    if mode == "embedded":
+        return pyseekdb.Client(path=client_config["path"], database=client_config["database"])
+    if mode == "oceanbase":
+        return pyseekdb.Client(
+            host=client_config["host"],
+            port=client_config["port"],
+            tenant=client_config["tenant"],
+            database=client_config["database"],
+            user=client_config["user"],
+            password=client_config["password"],
+        )
+    raise ValueError(f"unsupported client mode: {mode}")
+
+
+def _make_admin_client(client_config: dict[str, Any]):
+    pyseekdb = _import_pyseekdb()
+    mode = client_config["mode"]
+    if mode == "embedded":
+        return pyseekdb.AdminClient(path=client_config["path"])
+    if mode == "oceanbase":
+        return pyseekdb.AdminClient(
+            host=client_config["host"],
+            port=client_config["port"],
+            tenant=client_config["tenant"],
+            user=client_config["user"],
+            password=client_config["password"],
+        )
+    raise ValueError(f"unsupported client mode: {mode}")
 
 
 def _get_collection(client, collection_name: str):
     return client.get_collection(collection_name, embedding_function=None)
 
 
-def _refresh_collection(db_path: str, database: str, collection_name: str) -> None:
-    client = _make_client(db_path, database)
+def _refresh_collection(client_config: dict[str, Any], collection_name: str) -> None:
+    client = _make_client(client_config)
     collection = _get_collection(client, collection_name)
     collection.refresh_index()
 
@@ -123,7 +161,6 @@ def _run_processes(  # noqa: C901
             process.terminate()
         process.join(timeout=2)
 
-    results: list[dict[str, Any]] = []
     while len(results) < expected_count:
         try:
             results.append(result_queue.get(timeout=0.5))
@@ -134,8 +171,7 @@ def _run_processes(  # noqa: C901
 
 
 def _get_or_create_worker(
-    db_path: str,
-    database: str,
+    client_config: dict[str, Any],
     collection_name: str,
     delay: float,
     output: mp.Queue[dict[str, Any]],
@@ -144,7 +180,7 @@ def _get_or_create_worker(
     time.sleep(delay)
     try:
         pyseekdb = _import_pyseekdb()
-        client = pyseekdb.Client(path=db_path, database=database)
+        client = _make_client(client_config)
         collection = client.get_or_create_collection(
             collection_name,
             configuration=pyseekdb.HNSWConfiguration(dimension=EMBED_DIM, distance="cosine"),
@@ -156,8 +192,7 @@ def _get_or_create_worker(
 
 
 def _add_worker(
-    db_path: str,
-    database: str,
+    client_config: dict[str, Any],
     collection_name: str,
     process_id: int,
     threads_per_process: int,
@@ -167,7 +202,7 @@ def _add_worker(
     _purge_pyseekdb_modules()
 
     def add_in_thread(thread_id: int) -> int:
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
         embeddings = [_build_embedding(process_id * 10_000 + thread_id * 100 + seq) for seq in range(items_per_thread)]
@@ -188,8 +223,7 @@ def _add_worker(
 
 
 def _get_worker(
-    db_path: str,
-    database: str,
+    client_config: dict[str, Any],
     collection_name: str,
     process_id: int,
     threads_per_process: int,
@@ -199,7 +233,7 @@ def _get_worker(
     _purge_pyseekdb_modules()
 
     def get_in_thread(thread_id: int) -> int:
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
         result = collection.get(ids=ids, include=["documents", "metadatas"])
@@ -219,8 +253,7 @@ def _get_worker(
 
 
 def _query_worker(
-    db_path: str,
-    database: str,
+    client_config: dict[str, Any],
     collection_name: str,
     process_id: int,
     threads_per_process: int,
@@ -230,7 +263,7 @@ def _query_worker(
     _purge_pyseekdb_modules()
 
     def query_in_thread(thread_id: int) -> int:
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         completed = 0
         for query_idx in range(queries_per_thread):
@@ -257,8 +290,7 @@ def _query_worker(
 
 
 def _update_worker(
-    db_path: str,
-    database: str,
+    client_config: dict[str, Any],
     collection_name: str,
     process_id: int,
     threads_per_process: int,
@@ -268,7 +300,7 @@ def _update_worker(
     _purge_pyseekdb_modules()
 
     def update_in_thread(thread_id: int) -> int:
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
         metadatas = [
@@ -296,8 +328,7 @@ def _update_worker(
 
 
 def _delete_worker(
-    db_path: str,
-    database: str,
+    client_config: dict[str, Any],
     collection_name: str,
     process_id: int,
     threads_per_process: int,
@@ -307,7 +338,7 @@ def _delete_worker(
     _purge_pyseekdb_modules()
 
     def delete_in_thread(thread_id: int) -> int:
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
         collection.delete(ids=ids)
@@ -328,8 +359,7 @@ def _delete_worker(
 
 
 def _mixed_crud_worker(
-    db_path: str,
-    database: str,
+    client_config: dict[str, Any],
     collection_name: str,
     process_id: int,
     threads_per_process: int,
@@ -339,7 +369,7 @@ def _mixed_crud_worker(
     _purge_pyseekdb_modules()
 
     def mixed_in_thread(thread_id: int) -> dict[str, int]:
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         ids = [_record_id(process_id, thread_id, seq) for seq in range(items_per_thread)]
         embeddings = [_build_embedding(process_id * 10_000 + thread_id * 100 + seq) for seq in range(items_per_thread)]
@@ -404,54 +434,70 @@ def _mixed_crud_worker(
         output.put({"ok": False, "process_id": process_id, "error_type": type(exc).__name__, "error": str(exc)})
 
 
-@pytest.fixture
-def embedded_multiprocess_db():
-    _require_embedded_pylibseekdb()
+def _build_client_config(mode: str) -> tuple[dict[str, Any], Path | None]:
+    database = f"test_mp_{uuid.uuid4().hex[:8]}"
+    temp_db_path: Path | None = None
 
-    db_path = Path(tempfile.mkdtemp(prefix="seekdb-mp-"))
-    database = "test_mp"
+    if mode == "embedded":
+        _require_embedded_pylibseekdb()
+        temp_db_path = Path(tempfile.mkdtemp(prefix="seekdb-mp-"))
+        client_config = {"mode": "embedded", "path": str(temp_db_path), "database": database}
+    elif mode == "oceanbase":
+        client_config = {
+            "mode": "oceanbase",
+            "host": OB_HOST,
+            "port": OB_PORT,
+            "tenant": OB_TENANT,
+            "database": database,
+            "user": OB_USER,
+            "password": OB_PASSWORD,
+        }
+    else:
+        raise ValueError(f"unsupported test mode: {mode}")
 
-    pyseekdb = _import_pyseekdb()
-    admin = pyseekdb.AdminClient(path=str(db_path))
+    admin = _make_admin_client(client_config)
     admin.create_database(database)
     del admin
     gc.collect()
-
-    yield str(db_path), database
-
-    with contextlib.suppress(Exception):
-        shutil.rmtree(db_path, ignore_errors=True)
+    return client_config, temp_db_path
 
 
 @pytest.fixture
-def crud_collection(embedded_multiprocess_db):
-    db_path, database = embedded_multiprocess_db
+def multiprocess_db(_mode):
+    client_config, temp_db_path = _build_client_config(_mode)
+    yield client_config
+    if temp_db_path is not None:
+        with contextlib.suppress(Exception):
+            shutil.rmtree(temp_db_path, ignore_errors=True)
+
+
+@pytest.fixture
+def crud_collection(multiprocess_db):
+    client_config = multiprocess_db
     collection_name = f"mp_crud_{uuid.uuid4().hex}"
 
     pyseekdb = _import_pyseekdb()
-    client = pyseekdb.Client(path=db_path, database=database)
+    client = _make_client(client_config)
     client.create_collection(
         name=collection_name,
         configuration=pyseekdb.HNSWConfiguration(dimension=EMBED_DIM, distance="cosine"),
         embedding_function=None,
     )
 
-    yield db_path, database, collection_name
+    yield client_config, collection_name
 
     with contextlib.suppress(Exception):
         client.delete_collection(collection_name)
 
 
 def _seed_collection_rows(
-    db_path: str,
-    database: str,
+    client_config: dict[str, Any],
     collection_name: str,
     num_processes: int,
     threads_per_process: int,
     items_per_thread: int,
 ) -> int:
-    pyseekdb = _import_pyseekdb()
-    client = pyseekdb.Client(path=db_path, database=database)
+    client = _make_client(client_config)
     collection = _get_collection(client, collection_name)
 
     ids: list[str] = []
@@ -469,21 +515,21 @@ def _seed_collection_rows(
                 metadatas.append({"process_id": process_id, "thread_id": thread_id, "seq": seq})
 
     collection.add(ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)
-    _refresh_collection(db_path, database, collection_name)
+    _refresh_collection(client_config, collection_name)
     return len(ids)
 
 
 class TestGetOrCreateCollectionMultiprocess:
-    def test_concurrent_get_or_create_collection(self, embedded_multiprocess_db, _mode):
-        db_path, database = embedded_multiprocess_db
+    def test_concurrent_get_or_create_collection(self, multiprocess_db, _mode):
+        client_config = multiprocess_db
         collection_name = f"mp_collection_{uuid.uuid4().hex}"
 
         results = _run_processes(
             _get_or_create_worker,
             [
-                (db_path, database, collection_name, 0.0),
-                (db_path, database, collection_name, 0.05),
-                (db_path, database, collection_name, 0.1),
+                (client_config, collection_name, 0.0),
+                (client_config, collection_name, 0.05),
+                (client_config, collection_name, 0.1),
             ],
             expected_count=3,
         )
@@ -491,7 +537,7 @@ class TestGetOrCreateCollectionMultiprocess:
         assert len(results) == 3
         assert all(result["ok"] for result in results), results
 
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         try:
             assert client.has_collection(collection_name)
             collection = _get_collection(client, collection_name)
@@ -503,12 +549,12 @@ class TestGetOrCreateCollectionMultiprocess:
 
 class TestMultiprocessMultithreadCrud:
     def test_concurrent_add(self, crud_collection, _mode):
-        db_path, database, collection_name = crud_collection
+        client_config, collection_name = crud_collection
 
         results = _run_processes(
             _add_worker,
             [
-                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                (client_config, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
                 for process_id in range(NUM_PROCESSES)
             ],
             expected_count=NUM_PROCESSES,
@@ -521,20 +567,20 @@ class TestMultiprocessMultithreadCrud:
         total_inserted = sum(result["inserted"] for result in results)
         assert total_inserted == expected_rows
 
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         assert collection.count() == expected_rows
 
     def test_concurrent_get(self, crud_collection, _mode):
-        db_path, database, collection_name = crud_collection
+        client_config, collection_name = crud_collection
         expected_rows = _seed_collection_rows(
-            db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
+            client_config, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
         )
 
         results = _run_processes(
             _get_worker,
             [
-                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                (client_config, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
                 for process_id in range(NUM_PROCESSES)
             ],
             expected_count=NUM_PROCESSES,
@@ -545,13 +591,13 @@ class TestMultiprocessMultithreadCrud:
         assert sum(result["fetched"] for result in results) == expected_rows
 
     def test_concurrent_query(self, crud_collection, _mode):
-        db_path, database, collection_name = crud_collection
-        _seed_collection_rows(db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+        client_config, collection_name = crud_collection
+        _seed_collection_rows(client_config, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
 
         results = _run_processes(
             _query_worker,
             [
-                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                (client_config, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
                 for process_id in range(NUM_PROCESSES)
             ],
             expected_count=NUM_PROCESSES,
@@ -563,15 +609,15 @@ class TestMultiprocessMultithreadCrud:
         assert sum(result["queried"] for result in results) == expected_queries
 
     def test_concurrent_update(self, crud_collection, _mode):
-        db_path, database, collection_name = crud_collection
+        client_config, collection_name = crud_collection
         expected_rows = _seed_collection_rows(
-            db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
+            client_config, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
         )
 
         results = _run_processes(
             _update_worker,
             [
-                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                (client_config, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
                 for process_id in range(NUM_PROCESSES)
             ],
             expected_count=NUM_PROCESSES,
@@ -582,15 +628,15 @@ class TestMultiprocessMultithreadCrud:
         assert sum(result["updated"] for result in results) == expected_rows
 
     def test_concurrent_delete(self, crud_collection, _mode):
-        db_path, database, collection_name = crud_collection
+        client_config, collection_name = crud_collection
         expected_rows = _seed_collection_rows(
-            db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
+            client_config, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
         )
 
         results = _run_processes(
             _delete_worker,
             [
-                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                (client_config, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
                 for process_id in range(NUM_PROCESSES)
             ],
             expected_count=NUM_PROCESSES,
@@ -600,17 +646,17 @@ class TestMultiprocessMultithreadCrud:
         assert all(result["ok"] for result in results), results
         assert sum(result["deleted"] for result in results) == expected_rows
 
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         assert collection.count() == 0
 
     def test_concurrent_mixed_crud(self, crud_collection, _mode):
-        db_path, database, collection_name = crud_collection
+        client_config, collection_name = crud_collection
 
         results = _run_processes(
             _mixed_crud_worker,
             [
-                (db_path, database, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
+                (client_config, collection_name, process_id, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
                 for process_id in range(NUM_PROCESSES)
             ],
             expected_count=NUM_PROCESSES,
@@ -624,7 +670,7 @@ class TestMultiprocessMultithreadCrud:
         assert sum(result["added"] for result in results) == expected_added
         assert sum(result["deleted"] for result in results) == expected_deleted
 
-        client = _make_client(db_path, database)
+        client = _make_client(client_config)
         collection = _get_collection(client, collection_name)
         assert collection.count() == expected_added - expected_deleted
 

--- a/tests/integration_tests/test_get_or_create_collection_multiprocess.py
+++ b/tests/integration_tests/test_get_or_create_collection_multiprocess.py
@@ -36,6 +36,9 @@ THREADS_PER_PROCESS = 3
 ITEMS_PER_THREAD = 5
 WORKER_TIMEOUT_SECONDS = 60
 MIN_PYLIBSEEKDB_VERSION = Version("1.3.0.post1")
+_MP_CONTEXT = mp.get_context("spawn")
+
+pytestmark = pytest.mark.parametrize("_mode", ["embedded"], ids=["embedded"])
 
 
 def _purge_pyseekdb_modules() -> None:
@@ -89,20 +92,30 @@ def _require_embedded_pylibseekdb() -> None:
         )
 
 
-def _run_processes(
+def _run_processes(  # noqa: C901
     target: Callable[..., None],
     args_list: list[tuple[Any, ...]],
     expected_count: int,
     timeout: float = WORKER_TIMEOUT_SECONDS,
 ) -> list[dict[str, Any]]:
-    result_queue: mp.Queue[dict[str, Any]] = mp.Queue()
-    processes = [mp.Process(target=target, args=(*args, result_queue)) for args in args_list]
+    result_queue: mp.Queue[dict[str, Any]] = _MP_CONTEXT.Queue()
+    processes = [_MP_CONTEXT.Process(target=target, args=(*args, result_queue)) for args in args_list]
 
     for process in processes:
         process.start()
 
     deadline = time.time() + timeout
-    while time.time() < deadline and any(process.is_alive() for process in processes):
+    results: list[dict[str, Any]] = []
+    while time.time() < deadline:
+        while len(results) < expected_count:
+            try:
+                results.append(result_queue.get(timeout=0.1))
+            except Empty:
+                break
+        if len(results) >= expected_count and not any(process.is_alive() for process in processes):
+            break
+        if not any(process.is_alive() for process in processes) and len(results) < expected_count:
+            break
         time.sleep(0.1)
 
     for process in processes:
@@ -461,7 +474,7 @@ def _seed_collection_rows(
 
 
 class TestGetOrCreateCollectionMultiprocess:
-    def test_concurrent_get_or_create_collection(self, embedded_multiprocess_db):
+    def test_concurrent_get_or_create_collection(self, embedded_multiprocess_db, _mode):
         db_path, database = embedded_multiprocess_db
         collection_name = f"mp_collection_{uuid.uuid4().hex}"
 
@@ -489,7 +502,7 @@ class TestGetOrCreateCollectionMultiprocess:
 
 
 class TestMultiprocessMultithreadCrud:
-    def test_concurrent_add(self, crud_collection):
+    def test_concurrent_add(self, crud_collection, _mode):
         db_path, database, collection_name = crud_collection
 
         results = _run_processes(
@@ -512,7 +525,7 @@ class TestMultiprocessMultithreadCrud:
         collection = _get_collection(client, collection_name)
         assert collection.count() == expected_rows
 
-    def test_concurrent_get(self, crud_collection):
+    def test_concurrent_get(self, crud_collection, _mode):
         db_path, database, collection_name = crud_collection
         expected_rows = _seed_collection_rows(
             db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
@@ -531,7 +544,7 @@ class TestMultiprocessMultithreadCrud:
         assert all(result["ok"] for result in results), results
         assert sum(result["fetched"] for result in results) == expected_rows
 
-    def test_concurrent_query(self, crud_collection):
+    def test_concurrent_query(self, crud_collection, _mode):
         db_path, database, collection_name = crud_collection
         _seed_collection_rows(db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD)
 
@@ -549,7 +562,7 @@ class TestMultiprocessMultithreadCrud:
         expected_queries = NUM_PROCESSES * THREADS_PER_PROCESS * ITEMS_PER_THREAD
         assert sum(result["queried"] for result in results) == expected_queries
 
-    def test_concurrent_update(self, crud_collection):
+    def test_concurrent_update(self, crud_collection, _mode):
         db_path, database, collection_name = crud_collection
         expected_rows = _seed_collection_rows(
             db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
@@ -568,7 +581,7 @@ class TestMultiprocessMultithreadCrud:
         assert all(result["ok"] for result in results), results
         assert sum(result["updated"] for result in results) == expected_rows
 
-    def test_concurrent_delete(self, crud_collection):
+    def test_concurrent_delete(self, crud_collection, _mode):
         db_path, database, collection_name = crud_collection
         expected_rows = _seed_collection_rows(
             db_path, database, collection_name, NUM_PROCESSES, THREADS_PER_PROCESS, ITEMS_PER_THREAD
@@ -591,7 +604,7 @@ class TestMultiprocessMultithreadCrud:
         collection = _get_collection(client, collection_name)
         assert collection.count() == 0
 
-    def test_concurrent_mixed_crud(self, crud_collection):
+    def test_concurrent_mixed_crud(self, crud_collection, _mode):
         db_path, database, collection_name = crud_collection
 
         results = _run_processes(

--- a/tests/integration_tests/test_get_or_create_collection_multiprocess.py
+++ b/tests/integration_tests/test_get_or_create_collection_multiprocess.py
@@ -1,11 +1,12 @@
 """
-Integration tests for concurrent collection operations in embedded and OceanBase modes.
+Integration tests for concurrent collection operations across client modes.
 
 Covers multiprocess + multithread workloads. Each thread must use its own
 ``pyseekdb.Client`` instance because ``Client`` is not thread-safe.
 
-These tests are tagged with ``[embedded]`` / ``[oceanbase]`` and run only in the
-corresponding integration-test CI jobs, not in the unit-test integration step.
+Tests are parameterized with ``[embedded]``, ``[server]``, and ``[oceanbase]``
+so each runs in the matching integration-test CI job, not in the unit-test
+integration step.
 """
 
 from __future__ import annotations
@@ -42,13 +43,20 @@ WORKER_TIMEOUT_SECONDS = 60
 MIN_PYLIBSEEKDB_VERSION = Version("1.3.0.post1")
 _MP_CONTEXT = mp.get_context("spawn")
 
+SERVER_HOST = os.environ.get("SERVER_HOST", "127.0.0.1")
+SERVER_PORT = int(os.environ.get("SERVER_PORT", "2881"))
+SERVER_USER = os.environ.get("SERVER_USER", "root")
+SERVER_PASSWORD = os.environ.get("SERVER_PASSWORD", "")
+
 OB_HOST = os.environ.get("OB_HOST", "localhost")
 OB_PORT = int(os.environ.get("OB_PORT", "11202"))
 OB_TENANT = os.environ.get("OB_TENANT", "mysql")
 OB_USER = os.environ.get("OB_USER", "root")
 OB_PASSWORD = os.environ.get("OB_PASSWORD", "")
 
-pytestmark = pytest.mark.parametrize("_mode", ["embedded", "oceanbase"], ids=["embedded", "oceanbase"])
+pytestmark = pytest.mark.parametrize(
+    "_mode", ["embedded", "server", "oceanbase"], ids=["embedded", "server", "oceanbase"]
+)
 
 
 def _purge_pyseekdb_modules() -> None:
@@ -75,7 +83,7 @@ def _make_client(client_config: dict[str, Any]):
     mode = client_config["mode"]
     if mode == "embedded":
         return pyseekdb.Client(path=client_config["path"], database=client_config["database"])
-    if mode == "oceanbase":
+    if mode in ("server", "oceanbase"):
         return pyseekdb.Client(
             host=client_config["host"],
             port=client_config["port"],
@@ -92,7 +100,7 @@ def _make_admin_client(client_config: dict[str, Any]):
     mode = client_config["mode"]
     if mode == "embedded":
         return pyseekdb.AdminClient(path=client_config["path"])
-    if mode == "oceanbase":
+    if mode in ("server", "oceanbase"):
         return pyseekdb.AdminClient(
             host=client_config["host"],
             port=client_config["port"],
@@ -442,6 +450,16 @@ def _build_client_config(mode: str) -> tuple[dict[str, Any], Path | None]:
         _require_embedded_pylibseekdb()
         temp_db_path = Path(tempfile.mkdtemp(prefix="seekdb-mp-"))
         client_config = {"mode": "embedded", "path": str(temp_db_path), "database": database}
+    elif mode == "server":
+        client_config = {
+            "mode": "server",
+            "host": SERVER_HOST,
+            "port": SERVER_PORT,
+            "tenant": "sys",
+            "database": database,
+            "user": SERVER_USER,
+            "password": SERVER_PASSWORD,
+        }
     elif mode == "oceanbase":
         client_config = {
             "mode": "oceanbase",

--- a/tests/unit_tests/test_get_or_create_collection_concurrency.py
+++ b/tests/unit_tests/test_get_or_create_collection_concurrency.py
@@ -33,6 +33,17 @@ class TestCollectionConflictDetection:
     def test_ignores_unrelated_errors(self):
         assert not _is_collection_conflict_error(ValueError("invalid dimension"))
 
+    def test_ignores_metadata_failure_without_conflict_cause(self):
+        assert not _is_collection_conflict_error(
+            ValueError("Failed to create collection metadata: Collection not found: 'items'")
+        )
+
+    def test_detects_conflict_in_cause_chain(self):
+        inner = Exception("Table 'c$v2$abc' already exists failed: code=1050")
+        outer = ValueError("Failed to create collection metadata: duplicate entry")
+        outer.__cause__ = inner
+        assert _is_collection_conflict_error(outer)
+
 
 class TestGetOrCreateCollectionRecovery:
     def test_returns_existing_collection_after_create_conflict(self):
@@ -47,14 +58,15 @@ class TestGetOrCreateCollectionRecovery:
         assert result is existing
         client.get_collection.assert_called_once_with("items", embedding_function=_NOT_PROVIDED)
 
-    def test_retries_get_after_metadata_race(self):
+    def test_retries_get_after_wrapped_table_conflict(self):
         client = MagicMock(spec=BaseClient)
         client.has_collection.side_effect = [False, True]
         existing = object()
         client.get_collection.return_value = existing
-        client.create_collection.side_effect = ValueError(
-            "Failed to create collection metadata: Collection not found: 'items'"
-        )
+        inner = Exception("Table 'c$v2$abc' already exists failed: code=1050")
+        outer = ValueError("Failed to create collection metadata: duplicate entry")
+        outer.__cause__ = inner
+        client.create_collection.side_effect = outer
 
         result = BaseClient.get_or_create_collection(client, "items")
 

--- a/tests/unit_tests/test_get_or_create_collection_concurrency.py
+++ b/tests/unit_tests/test_get_or_create_collection_concurrency.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for concurrent-safe get_or_create_collection helpers.
+"""
+
+import contextlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+src_root = project_root / "src"
+sys.path.insert(0, str(src_root))
+
+from pyseekdb.client.client_base import (  # noqa: E402
+    BaseClient,
+    _is_collection_conflict_error,
+)
+from pyseekdb.client.types import _NOT_PROVIDED  # noqa: E402
+
+
+class TestCollectionConflictDetection:
+    def test_detects_value_error_for_existing_collection(self):
+        assert _is_collection_conflict_error(ValueError("Collection 'items' already exists"))
+
+    def test_detects_seekdb_table_exists_error(self):
+        class SeekdbError(Exception):
+            pass
+
+        exc = SeekdbError("Table 'c$v2$abc' already exists failed: code=1050")
+        assert _is_collection_conflict_error(exc)
+
+    def test_ignores_unrelated_errors(self):
+        assert not _is_collection_conflict_error(ValueError("invalid dimension"))
+
+
+class TestGetOrCreateCollectionRecovery:
+    def test_returns_existing_collection_after_create_conflict(self):
+        client = MagicMock(spec=BaseClient)
+        client.has_collection.side_effect = [False, True]
+        existing = object()
+        client.get_collection.return_value = existing
+        client.create_collection.side_effect = ValueError("Collection 'items' already exists")
+
+        with patch.object(BaseClient, "_collection_creation_lock", return_value=contextlib.nullcontext()):
+            result = BaseClient.get_or_create_collection(client, "items")
+
+        assert result is existing
+        client.get_collection.assert_called_once_with("items", embedding_function=_NOT_PROVIDED)
+
+    def test_retries_get_after_metadata_race(self):
+        client = MagicMock(spec=BaseClient)
+        client.has_collection.side_effect = [False, True]
+        existing = object()
+        client.get_collection.return_value = existing
+        client.create_collection.side_effect = ValueError(
+            "Failed to create collection metadata: Collection not found: 'items'"
+        )
+
+        with patch.object(BaseClient, "_collection_creation_lock", return_value=contextlib.nullcontext()):
+            result = BaseClient.get_or_create_collection(client, "items")
+
+        assert result is existing
+        client.get_collection.assert_called_once_with("items", embedding_function=_NOT_PROVIDED)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit_tests/test_get_or_create_collection_concurrency.py
+++ b/tests/unit_tests/test_get_or_create_collection_concurrency.py
@@ -2,10 +2,9 @@
 Unit tests for concurrent-safe get_or_create_collection helpers.
 """
 
-import contextlib
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -43,8 +42,7 @@ class TestGetOrCreateCollectionRecovery:
         client.get_collection.return_value = existing
         client.create_collection.side_effect = ValueError("Collection 'items' already exists")
 
-        with patch.object(BaseClient, "_collection_creation_lock", return_value=contextlib.nullcontext()):
-            result = BaseClient.get_or_create_collection(client, "items")
+        result = BaseClient.get_or_create_collection(client, "items")
 
         assert result is existing
         client.get_collection.assert_called_once_with("items", embedding_function=_NOT_PROVIDED)
@@ -58,8 +56,7 @@ class TestGetOrCreateCollectionRecovery:
             "Failed to create collection metadata: Collection not found: 'items'"
         )
 
-        with patch.object(BaseClient, "_collection_creation_lock", return_value=contextlib.nullcontext()):
-            result = BaseClient.get_or_create_collection(client, "items")
+        result = BaseClient.get_or_create_collection(client, "items")
 
         assert result is existing
         client.get_collection.assert_called_once_with("items", embedding_function=_NOT_PROVIDED)


### PR DESCRIPTION
## Summary
- Harden `get_or_create_collection` for embedded multi-process access by serializing creation with a file lock, making metadata insertion idempotent, and recovering from table-already-exists conflicts.
- Treat existing `sdk_collections` metadata as a valid collection during concurrent creation to close the check-then-act race window.
- Add unit tests for conflict detection/recovery and integration tests for multiprocess + multithread CRUD workloads (each thread uses its own `Client`).

## Test plan
- [x] `pytest tests/unit_tests/test_get_or_create_collection_concurrency.py -v`
- [x] `pytest tests/integration_tests/test_get_or_create_collection_multiprocess.py -v`
- [x] Manual multi-process repro via `test.py` (holder + contender processes)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust collection creation: tolerates pre-existing physical tables, preserves metadata, and avoids accidental deletes.
  * Improved conflict detection and name validation to prevent false "already exists" errors and recover cleanly from races.

* **Tests**
  * New integration tests exercising multi-process/multi-thread CRUD and concurrent get-or-create workflows.
  * New unit tests covering conflict detection and race-recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->