### PR TITLE
Keep embedded test data off system temp dirs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Run integration tests for ${{ matrix.test_mode }}
         env:
           CI: 1
-          SEEKDB_PATH: ${{ runner.temp }}/seekdb.db
+          SEEKDB_TEST_DATA_ROOT: ${{ github.workspace }}/.seekdb-test-data
           OB_PORT: 10000
           SERVER_PORT: 2881
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/_build/
 
 # tests
 seekdb.db/
+.seekdb-test-data/
 
 # demo
 .env

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -23,7 +23,9 @@ import pyseekdb  # noqa: E402
 
 # ==================== Environment Variable Configuration ====================
 # Embedded mode
-SEEKDB_PATH = os.environ.get("SEEKDB_PATH", os.path.join(repo_root, "seekdb.db"))
+# Keep database files off system temp directories, which may be tmpfs and reject O_DIRECT.
+SEEKDB_TEST_DATA_ROOT = Path(os.environ.get("SEEKDB_TEST_DATA_ROOT", str(repo_root / ".seekdb-test-data")))
+SEEKDB_PATH = os.environ.get("SEEKDB_PATH", str(SEEKDB_TEST_DATA_ROOT / "seekdb.db"))
 SEEKDB_DATABASE = os.environ.get("SEEKDB_DATABASE", "test")
 
 # Server mode

--- a/tests/integration_tests/test_get_or_create_collection_multiprocess.py
+++ b/tests/integration_tests/test_get_or_create_collection_multiprocess.py
@@ -55,6 +55,9 @@ OB_TENANT = os.environ.get("OB_TENANT", "mysql")
 OB_USER = os.environ.get("OB_USER", "root")
 OB_PASSWORD = os.environ.get("OB_PASSWORD", "")
 
+# Keep database files off system temp directories, which may be tmpfs and reject O_DIRECT.
+SEEKDB_TEST_DATA_ROOT = Path(os.environ.get("SEEKDB_TEST_DATA_ROOT", str(repo_root / ".seekdb-test-data")))
+
 pytestmark = pytest.mark.parametrize(
     "_mode", ["embedded", "server", "oceanbase"], ids=["embedded", "server", "oceanbase"]
 )
@@ -484,7 +487,8 @@ def _build_client_config(mode: str) -> tuple[dict[str, Any], Path | None, Any]:
 
     if mode == "embedded":
         _require_embedded_pylibseekdb()
-        temp_db_path = Path(tempfile.mkdtemp(prefix="seekdb-mp-"))
+        SEEKDB_TEST_DATA_ROOT.mkdir(parents=True, exist_ok=True)
+        temp_db_path = Path(tempfile.mkdtemp(prefix="seekdb-mp-", dir=SEEKDB_TEST_DATA_ROOT))
         client_config = {"mode": "embedded", "path": str(temp_db_path), "database": database}
     elif mode == "server":
         client_config = {


### PR DESCRIPTION
## Summary

- keep embedded SeekDB test data under a configurable `SEEKDB_TEST_DATA_ROOT`
- place GitHub Actions test data in the checked-out workspace instead of `runner.temp`
- create multiprocess embedded databases under the configured test-data root
- ignore the generated workspace-local test-data directory

## Root cause

Some CI hosts mount the system temporary directory as tmpfs. SeekDB opens its block file with `O_DIRECT`, so placing an embedded database there fails with `EINVAL` before the server becomes ready.

## Impact

This is a test-only workaround. Runtime client behavior is unchanged, and callers can override the test location with `SEEKDB_TEST_DATA_ROOT`.

## Validation

- `ruff check` passed
- `ruff format --check` passed
- related unit tests: 14 passed
- embedded multiprocess tests: 7 collected
- real embedded smoke test with `pylibseekdb 1.3.0.post1`: 1 passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test database configuration with a dedicated, configurable data directory.
  * Test databases now use consistent workspace-local storage instead of repository-root or system temporary locations.
* **Chores**
  * Added test data directories to ignore rules to prevent generated files from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->