### PR TITLE
Add test examples in github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,19 @@ jobs:
     strategy:
       fail-fast: false  # Allow other jobs to continue if one fails
       matrix:
-        test_mode: [embedded, server, oceanbase]
+        include:
+          - test_mode: embedded
+            example_host: 127.0.0.1
+            example_port: 2881
+            example_tenant: sys
+          - test_mode: server
+            example_host: 127.0.0.1
+            example_port: 2881
+            example_tenant: sys
+          - test_mode: oceanbase
+            example_host: localhost
+            example_port: 10000
+            example_tenant: mysql
 
     steps:
       - name: Free disk space
@@ -162,3 +174,28 @@ jobs:
           uv run pytest tests/integration_tests/ -v --log-cli-level=${log_level} \
             -k "${{ matrix.test_mode }}" | tee pytest.log
           bash .github/scripts/check-pytest-summary.sh pytest.log
+
+      - name: Run examples for ${{ matrix.test_mode }}
+        env:
+          MODE: ${{ matrix.test_mode }}
+          HOST: ${{ matrix.example_host }}
+          PORT: ${{ matrix.example_port }}
+          TENANT: ${{ matrix.example_tenant }}
+          DATABASE: test
+          SEEKDB_USER: root
+        run: |
+          for example_file in examples/*_example.py; do
+            if [[ "$example_file" == "examples/namespace_example.py" ]]; then
+              echo "Skipping ${example_file}: requires LakeBase 4.6.1+"
+              continue
+            fi
+
+            echo "Testing ${example_file} in ${MODE} mode"
+            if uv run python "$example_file"; then
+              echo "${example_file} passed"
+            else
+              status=$?
+              echo "${example_file} failed with exit code ${status}"
+              exit "$status"
+            fi
+          done

--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -35,6 +35,7 @@ elif mode == "server":
     client = pyseekdb.Client(
         host=os.getenv("HOST", "127.0.0.1"),
         port=int(os.getenv("PORT", "2881")),
+        tenant=os.getenv("TENANT", "sys"),
         database=os.getenv("DATABASE", "test"),
         user=os.getenv("SEEKDB_USER", "root"),
         password=os.getenv("SEEKDB_PASSWORD", ""),

--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -13,6 +13,7 @@ This is a complete reference for all client capabilities.
 """
 
 import logging
+import os
 import uuid
 
 import pyseekdb
@@ -23,26 +24,34 @@ logging.basicConfig(level=logging.DEBUG)
 # PART 1: CLIENT CONNECTION
 # ============================================================================
 
+mode = os.getenv("MODE", "embedded")
+
 # Option 1: Embedded mode (local seekdb)
-client = pyseekdb.Client(
-    # path="./seekdb.db",
-    # database="test"
-)
+if mode == "embedded":
+    client = pyseekdb.Client()
 
 # Option 2: Server mode (remote seekdb server)
-# client = pyseekdb.Client(
-#     host="127.0.0.1", port=2881, database="test", user="root", password=""
-# )
+elif mode == "server":
+    client = pyseekdb.Client(
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", "2881")),
+        database=os.getenv("DATABASE", "test"),
+        user=os.getenv("SEEKDB_USER", "root"),
+        password=os.getenv("SEEKDB_PASSWORD", ""),
+    )
 
 # Option 3: Remote server mode (OceanBase Server)
-# client = pyseekdb.Client(
-#     host="127.0.0.1",
-#     port=2881,
-#     tenant="test",  # OceanBase default tenant
-#     database="test",
-#     user="root",
-#     password=""
-# )
+elif mode == "oceanbase":
+    client = pyseekdb.Client(
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", "2881")),
+        tenant=os.getenv("TENANT", "test"),  # OceanBase default tenant
+        database=os.getenv("DATABASE", "test"),
+        user=os.getenv("SEEKDB_USER", "root"),
+        password=os.getenv("SEEKDB_PASSWORD", ""),
+    )
+else:
+    raise ValueError(f"Unsupported MODE: {mode}")
 
 # ============================================================================
 # PART 2: COLLECTION MANAGEMENT

--- a/examples/hybrid_search_example.py
+++ b/examples/hybrid_search_example.py
@@ -8,10 +8,25 @@ Key advantages of hybrid_search():
 - Handles complex scenarios that query() cannot
 """
 
+import os
+
 import pyseekdb
 
 # Setup
-client = pyseekdb.Client()
+mode = os.getenv("MODE", "embedded")
+if mode == "embedded":
+    client = pyseekdb.Client()
+elif mode in {"server", "oceanbase"}:
+    client = pyseekdb.Client(
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", "2881")),
+        tenant=os.getenv("TENANT", "sys" if mode == "server" else "test"),
+        database=os.getenv("DATABASE", "test"),
+        user=os.getenv("SEEKDB_USER", "root"),
+        password=os.getenv("SEEKDB_PASSWORD", ""),
+    )
+else:
+    raise ValueError(f"Unsupported MODE: {mode}")
 collection = client.get_or_create_collection(name="hybrid_search_demo")
 
 # Sample data

--- a/examples/namespace_example.py
+++ b/examples/namespace_example.py
@@ -7,17 +7,26 @@ Demonstrates:
 3. Vector query inside the namespace
 """
 
+import os
+
 import pyseekdb
 from pyseekdb import FulltextIndexConfig, IVFConfiguration, Schema, VectorIndexConfig
 
 # Connect to LakeBase / OceanBase (adjust host/port/credentials)
-client = pyseekdb.Client(
-    host="127.0.0.1",
-    port=2881,
-    database="test",
-    user="root@test",
-    password="",
-)
+mode = os.getenv("MODE", "oceanbase")
+if mode == "embedded":
+    client = pyseekdb.Client()
+elif mode in {"server", "oceanbase"}:
+    client = pyseekdb.Client(
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", "2881")),
+        tenant=os.getenv("TENANT", "sys" if mode == "server" else "test"),
+        database=os.getenv("DATABASE", "test"),
+        user=os.getenv("SEEKDB_USER", "root"),
+        password=os.getenv("SEEKDB_PASSWORD", ""),
+    )
+else:
+    raise ValueError(f"Unsupported MODE: {mode}")
 
 schema = Schema(
     vector_index=VectorIndexConfig(

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -11,32 +11,40 @@ This example demonstrates the most common operations with embedding functions:
 This is a minimal example to get you started quickly with embedding functions.
 """
 
+import os
+
 import pyseekdb
 
 # ==================== Step 1: Create Client Connection ====================
 # You can use embedded mode, server mode, or OceanBase mode
-# For this example, we'll use server mode (you can change to embedded or OceanBase)
+mode = os.getenv("MODE", "embedded")
 
 # Embedded mode (local seekdb)
-client = pyseekdb.Client(path="./seekdb.db", database="test")
+if mode == "embedded":
+    client = pyseekdb.Client(path="./seekdb.db", database="test")
+
 # Alternative: Server mode (connecting to remote seekdb server)
-# client = pyseekdb.Client(
-#     host="127.0.0.1",
-#     port=2881,
-#     database="test",
-#     user="root",
-#     password=""
-# )
+elif mode == "server":
+    client = pyseekdb.Client(
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", "2881")),
+        database=os.getenv("DATABASE", "test"),
+        user=os.getenv("SEEKDB_USER", "root"),
+        password=os.getenv("SEEKDB_PASSWORD", ""),
+    )
 
 # Alternative: Remote server mode (OceanBase Server)
-# client = pyseekdb.Client(
-#     host="127.0.0.1",
-#     port=2881,
-#     tenant="test",  # OceanBase default tenant
-#     database="test",
-#     user="root",
-#     password=""
-# )
+elif mode == "oceanbase":
+    client = pyseekdb.Client(
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", "2881")),
+        tenant=os.getenv("TENANT", "test"),  # OceanBase default tenant
+        database=os.getenv("DATABASE", "test"),
+        user=os.getenv("SEEKDB_USER", "root"),
+        password=os.getenv("SEEKDB_PASSWORD", ""),
+    )
+else:
+    raise ValueError(f"Unsupported MODE: {mode}")
 
 # ==================== Step 2: Create a Collection with Embedding Function ====================
 # A collection is like a table that stores documents with vector embeddings

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -28,6 +28,7 @@ elif mode == "server":
     client = pyseekdb.Client(
         host=os.getenv("HOST", "127.0.0.1"),
         port=int(os.getenv("PORT", "2881")),
+        tenant=os.getenv("TENANT", "sys"),
         database=os.getenv("DATABASE", "test"),
         user=os.getenv("SEEKDB_USER", "root"),
         password=os.getenv("SEEKDB_PASSWORD", ""),

--- a/examples/sparse_vector_index_example.py
+++ b/examples/sparse_vector_index_example.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 from typing import Any, Literal
 
 from transformers.utils import logging as hf_logging
@@ -19,8 +20,21 @@ from pyseekdb.utils.embedding_functions import BM25SparseEmbeddingFunction
 
 hf_logging.set_verbosity_error()
 
-# 1. Initialize client (Embedded mode; creates seekdb.db in the current directory)
-client = Client()
+# 1. Initialize client (Embedded mode by default; creates seekdb.db in the current directory)
+mode = os.getenv("MODE", "embedded")
+if mode == "embedded":
+    client = Client()
+elif mode in {"server", "oceanbase"}:
+    client = Client(
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", "2881")),
+        tenant=os.getenv("TENANT", "sys" if mode == "server" else "test"),
+        database=os.getenv("DATABASE", "test"),
+        user=os.getenv("SEEKDB_USER", "root"),
+        password=os.getenv("SEEKDB_PASSWORD", ""),
+    )
+else:
+    raise ValueError(f"Unsupported MODE: {mode}")
 
 # Clean up stale collections from previous runs
 for name in ["demo_sparse_collection", "hybrid_demo"]:


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

Closes #126

## Summary

- allow examples to select embedded, seekdb server, or OceanBase clients through environment variables
- discover and run `examples/*_example.py` in each integration test mode
- fail the GitHub Actions job when any example returns a non-zero exit code
- temporarily skip `namespace_example.py` because it requires LakeBase 4.6.1+

## Testing

- `make check`
- ran `complete_example.py` in embedded mode
- ran `hybrid_search_example.py` in embedded mode
- ran `simple_example.py` in embedded mode
- ran `sparse_vector_index_example.py` in embedded mode

Server and OceanBase modes are exercised by the GitHub Actions integration test matrix.

## Notes

`namespace_example.py` remains discoverable by the example test loop but is skipped explicitly because the current CI image does not support the required namespace functionality. Once a LakeBase 4.6.1+ image is available, the skip condition can be removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Example scripts now support embedded, server, and OceanBase connection modes.
  * Connection settings can be configured through environment variables, including host, port, database, and credentials.
  * Embedded mode is used by default where applicable, with clear errors for unsupported modes.

* **Tests**
  * Integration workflows now run example scripts across supported connection modes and report failures automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->